### PR TITLE
Fix Redoc docs loading by updating CDN js URL

### DIFF
--- a/src/quartz_api/cmd/redoc_theme.py
+++ b/src/quartz_api/cmd/redoc_theme.py
@@ -7,7 +7,7 @@ def get_redoc_html_with_theme(
     *,
     openapi_url: str = "./openapi.json",
     title: str,
-    redoc_js_url: str = "https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js",
+    redoc_js_url: str = "https://cdn.redoc.ly/redoc/v2.5.1/bundles/redoc.standalone.js",
     redoc_favicon_url: str = "/favicon.ico",
     with_google_fonts: bool = True,
 ) -> HTMLResponse:


### PR DESCRIPTION
# Pull Request

Fixes #125 

changed
`redoc_js_url: str = "https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js",`

to 
`redoc_js_url: str = "https://cdn.redoc.ly/redoc/v2.5.1/bundles/redoc.standalone.js",`