### PR TITLE
Fix Docker container ModuleNotFoundError (#143)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm AS build-deps
+FROM python:3.12-slim-bookworm AS build-deps
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -40,7 +40,7 @@ FROM python:3.12-slim-bookworm AS runtime
 
 WORKDIR /opt/app
 # Copy just the virtual environment into a runtime image
-COPY --from=build-app --chown=app:app /opt/app/.venv /opt/app/.venv
+COPY --from=build-app /opt/app/.venv /opt/app/.venv
 
 # Health check and entrypoint
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \


### PR DESCRIPTION
The container was failing to start because the quartz_api package wasn't being installed in the virtual environment. This was due to a Python version mismatch (3.11 vs 3.12) between the build and runtime stages.
Changes:
use python 3.12 consistently across build and runtime stages and remove invalid --chown=app:app flag as user doesnt exist at runtime Fix #143

# Pull Request

## How Has This Been Tested?

1. Reproduced the original issue:
   -Built the Docker image with the original Containerfile
   - error: `ModuleNotFoundError: No module named 'quartz_api'`
   - container failed to start

2. Verified the fix
   Built the Docker image with the fixed Containerfile
   Tested the import 

## What was fixed

- pythonversion mismatch: Build stage used 3.11 while runtime used 3.12, causing path inconsistencies
- removed invalid `--chown=app:app` flag that referenced a non-existent user