### PR TITLE
add middleware to log email to sentry

### DIFF
--- a/src/quartz_api/cmd/main.py
+++ b/src/quartz_api/cmd/main.py
@@ -33,15 +33,16 @@ import importlib.metadata
 import logging
 import pathlib
 import sys
-from collections.abc import Generator
+from collections.abc import Awaitable, Callable, Generator
 from contextlib import asynccontextmanager
 from typing import Any
 
 import uvicorn
 from dp_sdk.ocf import dp
-from fastapi import FastAPI, status
+from fastapi import FastAPI, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
+from fastapi.security import HTTPAuthorizationCredentials
 from grpclib.client import Channel
 from pydantic import BaseModel
 from pyhocon import ConfigFactory, ConfigTree
@@ -166,6 +167,7 @@ def _create_server(conf: ConfigTree) -> FastAPI:
             dsn=conf.get_string("sentry.dsn"),
             environment=conf.get_string("sentry.environment"),
             traces_sample_rate=1,
+            send_default_pii=True,
         )
 
         sentry_sdk.set_tag("server_name", "quartz_api")
@@ -189,19 +191,51 @@ def _create_server(conf: ConfigTree) -> FastAPI:
     # Customize the OpenAPI schema
     server.openapi = lambda: _custom_openapi(server)
 
+    # Store auth instance for middleware
+    auth_instance = None
+
     # Override dependencies according to configuration
     match (conf.get_string("auth0.domain"), conf.get_string("auth0.audience")):
         case (_, "") | ("", _):
-            server.dependency_overrides[auth.get_auth] = auth.DummyAuth()
+            auth_instance = auth.DummyAuth()
+            server.dependency_overrides[auth.get_auth] = auth_instance
             log.warning("disabled authentication. NOT recommended for production")
         case (domain, audience):
-            server.dependency_overrides[auth.get_auth] = auth.Auth0(
+            auth_instance = auth.Auth0(
                 domain=domain,
                 api_audience=audience,
                 algorithm="RS256",
             )
+            server.dependency_overrides[auth.get_auth] = auth_instance
         case _:
             raise ValueError("Invalid Auth0 configuration")
+
+
+# middleware to add user id and email to sentry
+    @server.middleware("http")
+    async def add_user_details_to_sentry(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        if auth_instance is not None and not isinstance(auth_instance, auth.DummyAuth):
+            try:
+                authorization = request.headers.get("Authorization", "")
+                if authorization.startswith("Bearer "):
+                    token = authorization.replace("Bearer ", "")
+                    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+                    payload = auth_instance(request, credentials)
+                    if payload:
+                        import sentry_sdk
+                        sentry_sdk.set_user({
+                            "id": payload.get("sub"),
+                            "email": payload.get(auth.EMAIL_KEY),
+                        })
+            except Exception:
+                # Silently fail to not break requests
+                log.debug("Could not extract user for Sentry")
+
+        response = await call_next(request)
+        return response
 
     timezone: str = conf.get_string("api.timezone")
     server.dependency_overrides[models.get_timezone] = lambda: timezone
@@ -218,7 +252,6 @@ def _create_server(conf: ConfigTree) -> FastAPI:
     server.add_middleware(time.TimerMiddleware)
 
     return server
-
 
 
 def run() -> None:

--- a/src/quartz_api/cmd/main.py
+++ b/src/quartz_api/cmd/main.py
@@ -33,16 +33,16 @@ import importlib.metadata
 import logging
 import pathlib
 import sys
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Generator
 from contextlib import asynccontextmanager
 from typing import Any
 
+import sentry_sdk
 import uvicorn
 from dp_sdk.ocf import dp
-from fastapi import FastAPI, Request, Response, status
+from fastapi import FastAPI, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
-from fastapi.security import HTTPAuthorizationCredentials
 from grpclib.client import Channel
 from pydantic import BaseModel
 from pyhocon import ConfigFactory, ConfigTree
@@ -51,7 +51,7 @@ from starlette.staticfiles import StaticFiles
 
 from quartz_api.internal import models, service
 from quartz_api.internal.backends import DataPlatformClient, DummyClient, QuartzClient
-from quartz_api.internal.middleware import audit, auth, time
+from quartz_api.internal.middleware import audit, auth, sentry, time
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
@@ -161,7 +161,6 @@ def _create_server(conf: ConfigTree) -> FastAPI:
 
     # Setup sentry, if configured
     if conf.get_string("sentry.dsn") != "":
-        import sentry_sdk
 
         sentry_sdk.init(
             dsn=conf.get_string("sentry.dsn"),
@@ -210,33 +209,6 @@ def _create_server(conf: ConfigTree) -> FastAPI:
         case _:
             raise ValueError("Invalid Auth0 configuration")
 
-
-# middleware to add user id and email to sentry
-    @server.middleware("http")
-    async def add_user_details_to_sentry(
-        request: Request,
-        call_next: Callable[[Request], Awaitable[Response]],
-    ) -> Response:
-        if auth_instance is not None and not isinstance(auth_instance, auth.DummyAuth):
-            try:
-                authorization = request.headers.get("Authorization", "")
-                if authorization.startswith("Bearer "):
-                    token = authorization.replace("Bearer ", "")
-                    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
-                    payload = auth_instance(request, credentials)
-                    if payload:
-                        import sentry_sdk
-                        sentry_sdk.set_user({
-                            "id": payload.get("sub"),
-                            "email": payload.get(auth.EMAIL_KEY),
-                        })
-            except Exception:
-                # Silently fail to not break requests
-                log.debug("Could not extract user for Sentry")
-
-        response = await call_next(request)
-        return response
-
     timezone: str = conf.get_string("api.timezone")
     server.dependency_overrides[models.get_timezone] = lambda: timezone
 
@@ -250,6 +222,10 @@ def _create_server(conf: ConfigTree) -> FastAPI:
     )
     server.add_middleware(audit.RequestLoggerMiddleware)
     server.add_middleware(time.TimerMiddleware)
+
+    # add sentry user middleware if auth gets configured
+    if auth_instance is not None and not isinstance(auth_instance, auth.DummyAuth):
+        server.add_middleware(sentry.SentryUserMiddleware, auth_instance=auth_instance)
 
     return server
 

--- a/src/quartz_api/cmd/main.py
+++ b/src/quartz_api/cmd/main.py
@@ -222,10 +222,7 @@ def _create_server(conf: ConfigTree) -> FastAPI:
     )
     server.add_middleware(audit.RequestLoggerMiddleware)
     server.add_middleware(time.TimerMiddleware)
-
-    # add sentry user middleware if auth gets configured
-    if auth_instance is not None and not isinstance(auth_instance, auth.DummyAuth):
-        server.add_middleware(sentry.SentryUserMiddleware, auth_instance=auth_instance)
+    server.add_middleware(sentry.SentryUserMiddleware, auth_instance=auth_instance)
 
     return server
 

--- a/src/quartz_api/internal/middleware/sentry.py
+++ b/src/quartz_api/internal/middleware/sentry.py
@@ -1,0 +1,57 @@
+"""Middleware to add user details to sentry for error tracking."""
+
+import logging
+from collections.abc import Awaitable, Callable
+
+from fastapi import FastAPI, Request, Response
+from fastapi.security import HTTPAuthorizationCredentials
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from quartz_api.internal.middleware import auth
+
+log = logging.getLogger(__name__)
+
+
+class SentryUserMiddleware(BaseHTTPMiddleware):
+    """add user details to sentry for HTTP requests."""
+
+    def __init__(
+        self,
+        server: FastAPI,
+        auth_instance: auth.Auth0 | auth.DummyAuth,
+    ) -> None:
+        """Initialize FastAPI server and auth instance."""
+        super().__init__(server)
+        self.auth_instance = auth_instance
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        """Add user details to a context before processing request."""
+        if self.auth_instance is not None and not isinstance(
+            self.auth_instance, auth.DummyAuth,
+        ):
+            try:
+                authorization = request.headers.get("Authorization", "")
+                if authorization.startswith("Bearer "):
+                    token = authorization.replace("Bearer ", "")
+                    credentials = HTTPAuthorizationCredentials(
+                        scheme="Bearer", credentials=token,
+                    )
+                    payload = self.auth_instance(request, credentials)
+                    if payload:
+                        import sentry_sdk
+
+                        sentry_sdk.set_user({
+                            "id": payload.get("sub"),
+                            "email": payload.get(auth.EMAIL_KEY),
+                        })
+            except Exception:
+                # silently fail to not break requests
+                log.debug("Could not extract user for Sentry")
+
+        response = await call_next(request)
+        return response
+


### PR DESCRIPTION
# Pull Request
added the middleware to get user email from jwt tokens and set it to sentry user context, the middleware gets the email from the payload using the EMAIL_KEY and sets user to the sdk. also, an auth_instance variable to directly validate tokens.

Fixes #121 

## How Has This Been Tested?
not tested

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
