### PR TITLE
Add pytest for csv file download

### DIFF
--- a/src/quartz_api/internal/backends/quartzdb/test_csv_download.py
+++ b/src/quartz_api/internal/backends/quartzdb/test_csv_download.py
@@ -1,11 +1,14 @@
 """Test CSV download endpoint."""
 
+import datetime as dt
 import io
 import pathlib
 
 import pandas as pd
 import pytest
 from fastapi.testclient import TestClient
+from pvsite_datamodel.read.model import get_or_create_model
+from pvsite_datamodel.sqlmodels import ForecastSQL, ForecastValueSQL, LocationSQL
 from pyhocon import ConfigFactory
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
@@ -14,9 +17,6 @@ from quartz_api.cmd.main import _create_server
 from quartz_api.internal import models
 
 from .client import Client
-import datetime as dt
-from pvsite_datamodel.read.model import get_or_create_model
-from pvsite_datamodel.sqlmodels import ForecastSQL, ForecastValueSQL, LocationSQL
 
 
 @pytest.fixture()
@@ -34,28 +34,27 @@ def test_client(client: Client) -> TestClient:
     # Load config and override routers to include 'regions'
     conf_path = pathlib.Path(__file__).parent.parent.parent.parent / "cmd" / "server.conf"
     conf = ConfigFactory.parse_file(conf_path.as_posix())
-    
+
     # Override config to include regions router
     override_conf = ConfigFactory.from_dict({"api": {"routers": "regions"}})
     conf = override_conf.with_fallback(conf)
-    
+
     # Create the FastAPI app
     app = _create_server(conf=conf)
-    
+
     # Override the database dependency with our test client
     app.dependency_overrides[models.get_db_client] = lambda: client
-    
+
     return TestClient(app)
 
 
 class TestCsvDownload:
     """Test CSV download functionality."""
 
+    @pytest.mark.usefixtures("forecast_values_wind")
     def test_csv_download_success(
         self,
         test_client: TestClient,
-        client: Client,
-        forecast_values_wind: None,
     ) -> None:
         """Test successful CSV download from the API endpoint."""
         # Make request to CSV download endpoint
@@ -81,24 +80,24 @@ class TestCsvDownload:
         assert "PowerMW" in df.columns
         assert len(df) > 0
 
+    @pytest.mark.usefixtures("forecast_values_wind")
     def test_csv_download_day_ahead(
         self,
         test_client: TestClient,
         client: Client,
-        forecast_values_wind: None,
     ) -> None:
         """Test CSV download with day_ahead forecast horizon."""
-        
+
         # 1. Setup: Create 'Day Ahead' forecast data (for tomorrow)
         # Get the wind site
         site = client.session.query(LocationSQL).filter(LocationSQL.asset_type == "wind").first()
-        
+
         # Create a forecast timestamped now
         now = dt.datetime.now(tz=dt.UTC)
-        
+
         # Create a model entry
         ml_model = get_or_create_model(client.session, "windnet_india_adjust")
-        
+
         forecast = ForecastSQL(
             location_uuid=site.location_uuid,
             forecast_version="0.0.0",
@@ -106,18 +105,18 @@ class TestCsvDownload:
         )
         client.session.add(forecast)
         client.session.commit()
-        
+
         # Add forecast values for "Tomorrow"
-        # We need data that falls into "tomorrow" in IST. 
+        # We need data that falls into "tomorrow" in IST.
         # IST is UTC+5:30.
         # Let's just generate 24 hours of data starting from now + 24h to be safe
         start_future = now + dt.timedelta(hours=24)
-        
+
         forecast_values = []
-        for i in range(48): # 12 hours of data
+        for i in range(48):  # 12 hours of data
             start_utc = start_future + dt.timedelta(minutes=15 * i)
             end_utc = start_utc + dt.timedelta(minutes=15)
-            
+
             fv = ForecastValueSQL(
                 forecast_power_kw=123.45 + i,
                 forecast_uuid=forecast.forecast_uuid,
@@ -127,7 +126,7 @@ class TestCsvDownload:
             )
             fv.ml_model = ml_model
             forecast_values.append(fv)
-            
+
         client.session.add_all(forecast_values)
         client.session.commit()
 


### PR DESCRIPTION
## Description

This PR adds comprehensive integration tests for the wind forecast CSV download endpoint. It ensures that the API correctly handles different forecast horizons and returns the expected CSV structure (including IST timezone formatting).

Fixes #74 

**Changes:**
- Created `TestCsvDownload` class in the test suite.
- Added `test_csv_download_success` to verify the "latest" forecast horizon.
- Added `test_csv_download_day_ahead` to verify future-dated forecast data retrieval.
- Verified correct CSV headers: `Date [IST]`, `Time`, and `PowerMW`.

## How Has This Been Tested?

I have implemented and ran the following automated tests using `pytest` and the `FastAPI TestClient`:
1. **Latest Horizon Test:** Verified that calling the endpoint returns a 200 status code and a valid CSV with data.
2. **Day Ahead Test:** Verified that the endpoint correctly filters or identifies data meant for the next day's forecast.
3. **Structure Check:** Asserted that response headers include the correct `content-disposition` for file downloads and that the pandas-parsed CSV contains the required columns.

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings