### PR TITLE
remove tags, as we show this in the descriptions of the apis now

### DIFF
--- a/src/quartz_api/cmd/main.py
+++ b/src/quartz_api/cmd/main.py
@@ -60,6 +60,7 @@ def _custom_openapi(server: FastAPI) -> dict[str, Any]:
     )
 
     openapi_schema["info"]["x-logo"] = {"url": "/static/logo.png"}
+    openapi_schema["tags"] = server.openapi_tags
     server.openapi_schema = openapi_schema
 
     return openapi_schema
@@ -159,13 +160,7 @@ def _create_server(conf: ConfigTree) -> FastAPI:
 
         except ModuleNotFoundError as e:
             raise OSError(f"No such router router '{r}'") from e
-        server.openapi_tags = [
-            {
-                "name": mod.__name__.split(".")[-1].capitalize(),
-                "description": mod.__doc__,
-            },
-            *server.openapi_tags,
-        ]
+
 
     # Customize the OpenAPI schema
     server.openapi = lambda: _custom_openapi(server)


### PR DESCRIPTION
# Pull Request

## Description

Remove tags from openapi_schema. 

This means the description for router doesnt appear twice

Currently we get
<img width="1204" height="987" alt="Screenshot 2026-01-07 at 14 11 42" src="https://github.com/user-attachments/assets/599b0ef1-4129-4f6a-afb9-5ee58eaa42b2" />

In future we might want to split it things into two two
- tag descriptions
- route descriptions for 

## How Has This Been Tested?

- ran this locally

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
