### PR TITLE
set_consumer in auth route

### DIFF
--- a/src/quartz_api/internal/middleware/auth.py
+++ b/src/quartz_api/internal/middleware/auth.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Annotated
 
+from apitally.fastapi import set_consumer
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPBearer
 from fastapi_plugin.fast_api_client import Auth0FastAPI
@@ -81,10 +82,13 @@ class AuthClient:
 
                 raise e
 
+            # set the apitally consumer, this means we can see who has used which routes
+            email = claims["https://openclimatefix.org/email"]
+            set_consumer(request,identifier=email)
+
             return claims
 
         return _proxy_dependency
-
 
 auth_instance = AuthClient()
 


### PR DESCRIPTION
# Pull Request

## Description

added apitally consumers https://docs.apitally.io/features/consumer-insights

## How Has This Been Tested?

- CI tests
- ran it locally, and consumers appear in apitally
- doesnt through error, if apitally not set up

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
