### PR TITLE
add formating for forecast metadata

### DIFF
--- a/src/quartz_api/internal/backends/dataplatform/client.py
+++ b/src/quartz_api/internal/backends/dataplatform/client.py
@@ -166,6 +166,7 @@ class StorageClient(models.StorageInterface):
                 }
                 if "p10" in v.other_statistics_fractions and "p90" in v.other_statistics_fractions
                 else {},
+                metadata=struct_to_dict(v.metadata),
             )
             for v in resp.values
         ]

--- a/src/quartz_api/internal/models/db_interface.py
+++ b/src/quartz_api/internal/models/db_interface.py
@@ -49,6 +49,9 @@ class PredictedGenerationValue(GenerationValue):
     and values are the corresponding power values in kW."""
     plevels_kilowatts: dict[str, float] = Field(default_factory=dict)
 
+    # metadata: Additional metadata about the forecast
+    metadata: dict[str, str | float] = Field(default_factory=dict)
+
 
 class ActualGenerationValue(GenerationValue):
     """Generation value recorded by an observer."""

--- a/src/quartz_api/internal/service/uk_national/national_router.py
+++ b/src/quartz_api/internal/service/uk_national/national_router.py
@@ -133,14 +133,16 @@ async def get_national_forecast(
     else:
         # Legacy inputdata,
         # In nowcasting_datamodel, we get this from the database
-        old = dt.datetime(1970, 1, 1, tzinfo=dt.UTC)
-        input_data = InputDataLastUpdated(gsp=old, nwp=old, pv=old, satellite=old)
+        input_data = format_metadata(pgvs[0].metadata)
+
+        # get version
+        version = pgvs[0].metadata.get("app_version", pgvs[0].forecaster_version)
 
         national_forecast = NationalForecast(
             location=Location.from_location(nation),
             model=MLModel(
                 name=pgvs[0].forecaster_name,
-                version=pgvs[0].forecaster_version,
+                version=version,
             ),
             forecast_creation_time=pgvs[0].created_timestamp,
             initialization_datetime_utc=pgvs[0].init_timestamp,
@@ -208,3 +210,16 @@ async def get_national_pvlive(
     ]
 
     return out
+
+
+def format_metadata(metadata: dict) -> InputDataLastUpdated:
+    """Format metadata dictionary into InputDataLastUpdated object."""
+    old = dt.datetime(1970, 1, 1, tzinfo=dt.UTC)
+    gsp = metadata.get("gsp_last_updated", old)
+    satellite = metadata.get("satellite_last_updated", old)
+
+    # the nwp keys could be nwp_ukv_last_updated, nwp_ecwmwf_last_updated, or nwp_last_updated
+    nwp = old
+    for nwp_key in [k for k in metadata if "nwp" in k]:
+        nwp = max([metadata.get(nwp_key, old)])
+    return InputDataLastUpdated(gsp=gsp, nwp=nwp, pv=old, satellite=satellite)

--- a/src/quartz_api/internal/service/uk_national/test_national_router.py
+++ b/src/quartz_api/internal/service/uk_national/test_national_router.py
@@ -1,0 +1,26 @@
+""" Test for format metadata"""
+import datetime as dt
+
+from .national_router import format_metadata
+
+
+def test_format_metadata():
+    metadata = {
+        "gsp_last_updated": dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.UTC),
+        "nwp_ukv_last_updated": dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.UTC),
+        "nwp_ecmwf_last_updated": dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.UTC),
+    }
+    result = format_metadata(metadata)
+    assert result.gsp == dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.UTC)
+    assert result.nwp == dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.UTC)
+    assert result.satellite == dt.datetime(1970, 1, 1, tzinfo=dt.UTC)
+
+def test_format_metadata_no_nwp():
+    metadata = {
+        "gsp_last_updated": dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.UTC),
+        "app_version": "1.2.3",
+    }
+    result = format_metadata(metadata)
+    assert result.gsp == dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.UTC)
+    assert result.nwp == dt.datetime(1970, 1, 1, tzinfo=dt.UTC)
+    assert result.satellite == dt.datetime(1970, 1, 1, tzinfo=dt.UTC)

--- a/src/quartz_api/tests/integration/uk_national/conftest.py
+++ b/src/quartz_api/tests/integration/uk_national/conftest.py
@@ -163,6 +163,7 @@ def forecast(location_uuid: str, name: str, init_time_utc: datetime) -> dp.Creat
             )
             for i in range(10)
         ],
+        metadata=Struct(fields={"app_version": Value(string_value="1.2.3")}),
     )
 
 

--- a/src/quartz_api/tests/integration/uk_national/test_app.py
+++ b/src/quartz_api/tests/integration/uk_national/test_app.py
@@ -91,6 +91,7 @@ async def test_national_forecast_metadata_true_and_false(
             data[i]["expectedPowerGenerationMegawatts"]
             == data_metadata["forecastValues"][i]["expectedPowerGenerationMegawatts"]
         )
+    assert data_metadata["model"]["version"] == "1.2.3"
 
 
 # 3.1 Test the National PVlive route


### PR DESCRIPTION
# Pull Request

## Description

- when including metadata, get the values from the forecast metadata

Helps with https://github.com/openclimatefix/client-private/issues/245

## How Has This Been Tested?

- [x] CI tests
- [x] new tests

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
