### PR TITLE
use last forecast metadata

### DIFF
--- a/src/quartz_api/internal/service/uk_national/national_router.py
+++ b/src/quartz_api/internal/service/uk_national/national_router.py
@@ -133,10 +133,10 @@ async def get_national_forecast(
     else:
         # Legacy inputdata,
         # In nowcasting_datamodel, we get this from the database
-        input_data = format_metadata(pgvs[0].metadata)
+        input_data = format_metadata(pgvs[-1].metadata)
 
         # get version
-        version = pgvs[0].metadata.get("app_version", pgvs[0].forecaster_version)
+        version = pgvs[-1].metadata.get("app_version", pgvs[-1].forecaster_version)
 
         national_forecast = NationalForecast(
             location=Location.from_location(nation),


### PR DESCRIPTION
# Pull Request

## Description

Use the last forecast metadata, rather than the first on
Fixes for https://github.com/openclimatefix/client-private/issues/245

## How Has This Been Tested?

- [x] CI tests
- [x] ran it locally

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
