### PR TITLE
dont raise error, but return [] when gsp doesnt exist

### DIFF
--- a/src/quartz_api/internal/service/uk_national/gsp_router.py
+++ b/src/quartz_api/internal/service/uk_national/gsp_router.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import datetime as dt
+import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, Annotated
 
@@ -29,7 +30,10 @@ from .time_utils import (
 if TYPE_CHECKING:
     from uuid import UUID
 
+log = logging.getLogger(__name__)
+
 router = APIRouter(tags=["GSP"])
+
 
 
 @router.get(
@@ -78,10 +82,8 @@ async def get_forecasts_for_a_specific_gsp(
     )
     filtered_gsps = [g for g in gsps if int(g.metadata["gsp_id"]) == gsp_id]
     if len(filtered_gsps) != 1:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"GSP with gsp_id {gsp_id} not found",
-        )
+        log.warning(f"GSP with gsp_id {gsp_id} not found")
+        return []
     gsp = filtered_gsps[0]
 
     pgvs = await db.get_predicted_generation(

--- a/src/quartz_api/tests/integration/uk_national/test_app.py
+++ b/src/quartz_api/tests/integration/uk_national/test_app.py
@@ -145,6 +145,23 @@ async def test_gsp_forecast(
     assert len(data) == 10
 
 
+# 4.1.1 Check GSP forecast route - no gsp location
+@pytest.mark.asyncio(loop_scope="session")
+async def test_gsp_forecast_no_location(
+    api_client,
+    gsp_locations,  # noqa arg001
+    make_forecasters,  # noqa arg001
+    make_gsp_forecast_values,  # noqa arg001
+) -> None:
+    """Test a sample endpoint for UK National forecast data."""
+
+    response = await api_client.get("/v0/solar/GB/gsp/100/forecast")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 0
+
+
 # 4.2 Check GSP pvlive route
 @pytest.mark.asyncio(loop_scope="session")
 async def test_gsp_pvlive(


### PR DESCRIPTION
# Pull Request

## Description

change the `gsp/{gsp_id}/forecast` behaviour if the gsp doesnt exsits. If it doesnt exist then return an empty list. This is what current api does.

Helps with https://github.com/openclimatefix/client-private/issues/256

## How Has This Been Tested?

- [x] CI tests
- [x] tested locally with dev data-platform

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
