### PR TITLE
fix[national]: set created_cutoff to get forecast values at start of …

### DIFF
--- a/src/quartz_api/internal/backends/dataplatform/client.py
+++ b/src/quartz_api/internal/backends/dataplatform/client.py
@@ -63,7 +63,7 @@ class StorageClient(models.StorageInterface):
 
         # Limit the creation time if not set
         if created_cutoff is None:
-            created_cutoff = dt.datetime.now(tz=dt.UTC) - \
+            created_cutoff = window_start - \
                 dt.timedelta(minutes=forecast_horizon_minutes)
 
         oauth_id: str | None = get_oauth_id_from_sub(authdata["sub"]) if authdata != {} else None


### PR DESCRIPTION
…default window

# Pull Request

## Description

This should mean the forecast should go back to the beginning of the default window: 48h back, rounded down to 6h tick.

Fixes https://github.com/openclimatefix/client-private/issues/263

## How Has This Been Tested?

- [x] Locally against dev DP

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
