### PR TITLE
use timezone when calculating start time

### DIFF
--- a/src/quartz_api/internal/service/uk_national/national_router.py
+++ b/src/quartz_api/internal/service/uk_national/national_router.py
@@ -25,7 +25,7 @@ from .endpoint_types import (
     gsp_id_map,
     model_names_external_to_internal,
 )
-from .time_utils import limit_end_datetime_by_permissions, get_start_window
+from .time_utils import get_start_window, limit_end_datetime_by_permissions
 
 log = logging.getLogger(__name__)
 

--- a/src/quartz_api/internal/service/uk_national/national_router.py
+++ b/src/quartz_api/internal/service/uk_national/national_router.py
@@ -25,7 +25,7 @@ from .endpoint_types import (
     gsp_id_map,
     model_names_external_to_internal,
 )
-from .time_utils import limit_end_datetime_by_permissions
+from .time_utils import limit_end_datetime_by_permissions, get_start_window
 
 log = logging.getLogger(__name__)
 
@@ -134,7 +134,7 @@ async def get_national_forecast(
     # we get from from now - rounded up to nearest 30 mins, less 3 days.
     if start_datetime_utc is None:
         start_datetime_utc \
-            = pd.Timestamp.utcnow().floor("6h").to_pydatetime() - dt.timedelta(days=2)
+            = get_start_window()
         if include_metadata:
             start_datetime_utc \
                 = pd.Timestamp.utcnow().ceil("30min").to_pydatetime() - dt.timedelta(days=3)
@@ -267,7 +267,7 @@ async def get_national_pvlive(
         location_uuid=uk_loc.uuid,
         energy_type=models.EnergyType.SOLAR,
         location_type=models.LocationType.NATION,
-        window_start=pd.Timestamp.utcnow().floor("6h").to_pydatetime() - dt.timedelta(days=2),
+        window_start=get_start_window(),
         window_end=pd.Timestamp.utcnow().floor("6h").to_pydatetime() + dt.timedelta(days=2),
         observer_name=f"pvlive_{regime}",
         authdata={},

--- a/src/quartz_api/internal/service/uk_national/time_utils.py
+++ b/src/quartz_api/internal/service/uk_national/time_utils.py
@@ -1,6 +1,7 @@
 """Utility functions for handling datetime objects in UK National context."""
 
 import datetime as dt
+import pandas as pd
 import os
 
 import sentry_sdk
@@ -34,3 +35,14 @@ def limit_end_datetime_by_permissions(
         return min(end_datetime_utc, intraday_max_allowed)
 
     return end_datetime_utc
+
+def get_start_window():
+    now = pd.Timestamp.utcnow()
+    # set as uk london timezone
+    now_london = now.tz_convert("Europe/London")
+    # round and move back 2 days
+    now_minus_2_days_london = now_london.floor("6h") - dt.timedelta(days=2)
+    # change back to utc
+    now_minus_2_days_utc = now_minus_2_days_london.tz_convert("UTC")
+
+    return now_minus_2_days_utc

--- a/src/quartz_api/internal/service/uk_national/time_utils.py
+++ b/src/quartz_api/internal/service/uk_national/time_utils.py
@@ -1,9 +1,9 @@
 """Utility functions for handling datetime objects in UK National context."""
 
 import datetime as dt
-import pandas as pd
 import os
 
+import pandas as pd
 import sentry_sdk
 
 from quartz_api.internal import models
@@ -36,7 +36,8 @@ def limit_end_datetime_by_permissions(
 
     return end_datetime_utc
 
-def get_start_window():
+def get_start_window() -> pd.Timestamp:
+    """Get the start window for the forecast query."""
     now = pd.Timestamp.utcnow()
     # set as uk london timezone
     now_london = now.tz_convert("Europe/London")


### PR DESCRIPTION
# Pull Request

## Description

- Use uk london timezone
- This is the same as the old api - [here](https://github.com/openclimatefix-archives/uk-pv-national-gsp-api/blob/main/nowcasting_api/utils.py#L118)

Helps with https://github.com/openclimatefix/client-private/issues/348#issuecomment-4179184307

## How Has This Been Tested?

- CI tests

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
