### PR TITLE
fix: disable Apitally body logging to reduce memory growth

### DIFF
--- a/src/quartz_api/cmd/main.py
+++ b/src/quartz_api/cmd/main.py
@@ -280,9 +280,9 @@ def _create_server(conf: ConfigTree) -> FastAPI:
             env=conf.get_string("apitally.environment"),
             enable_request_logging=True,
             log_request_headers=True,
-            log_request_body=True,
-            log_response_body=True,
-            capture_logs=True,
+            log_request_body=False,
+            log_response_body=False,
+            capture_logs=False,
         )
 
     server.add_middleware(trace.TracerMiddleware)


### PR DESCRIPTION
# Pull Request

## Description

Disable Apitally request/response body logging to reduce memory growth (#276).

The `ApitallyMiddleware` was buffering full request and response bodies in memory for every API call. For forecast endpoints returning multi-MB payloads, this accumulates ~250MB/day.

Changes:
- `log_request_body`: True → False
- `log_response_body`: True → False
- `capture_logs`: True → False

Request logging and header logging remain enabled.

**Note:** The `InMemoryBackend()` cache on line 171 is also unbounded — consider a bounded cache or Redis backend as a follow-up.

## How Has This Been Tested?

- [x] Reviewed Apitally SDK source — defaults are already `False`
- [x] Verified no tests depend on body logging
- [x] CI tests

## Checklist:

- [x] My code follows OCF's coding style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings