### PR TITLE
make auth more robust, if not email key

### DIFF
--- a/src/quartz_api/internal/middleware/auth.py
+++ b/src/quartz_api/internal/middleware/auth.py
@@ -86,6 +86,8 @@ class AuthClient:
             if EMAIL_KEY in claims:
                 email = claims[EMAIL_KEY]
                 set_consumer(request, identifier=email)
+            else:
+                log.warning("Authentication passed but could not find email claim in JWT")
 
             return claims
 

--- a/src/quartz_api/internal/middleware/auth.py
+++ b/src/quartz_api/internal/middleware/auth.py
@@ -83,8 +83,9 @@ class AuthClient:
                 raise e
 
             # set the apitally consumer, this means we can see who has used which routes
-            email = claims["https://openclimatefix.org/email"]
-            set_consumer(request,identifier=email)
+            if EMAIL_KEY in claims:
+                email = claims[EMAIL_KEY]
+                set_consumer(request, identifier=email)
 
             return claims
 


### PR DESCRIPTION
# Pull Request

## Description

Fix if the authentication has no email key. This can happen if auth is done via secret id and key. 

Helps with https://github.com/openclimatefix/client-private/issues/418

## How Has This Been Tested?

- CI tests

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
