### PR TITLE
Reduce national forecast cache from 120s to 30s

### DIFF
--- a/src/quartz_api/internal/service/uk_national/national_router.py
+++ b/src/quartz_api/internal/service/uk_national/national_router.py
@@ -85,7 +85,7 @@ FORECASTER_VERSION_PVNET = "2.8.0"
         },
     },
 )
-@cache(key_builder=key_builder)
+@cache(key_builder=key_builder, expire=30)
 async def get_national_forecast(
     request: Request,  # noqa: ARG001
     db: models.StorageClientDependency,


### PR DESCRIPTION
Closes #302

# Pull Request

## Description

Reduces the cache duration for the `/national/forecast` route from 120 seconds to 30 seconds by passing `expire=30` to its `@cache` decorator. The global default in `main.py` stays at 120s; only this route is affected, as per the issue.

Fixes #302 

## How Has This Been Tested?

Verified the existing test suite passes with the change. The route behaviour is unchanged, and only the cache TTL is reduced.

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

No changes in data preprocessing.

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
