### PR TITLE
remove cache if it is expired

### DIFF
--- a/src/quartz_api/cmd/main.py
+++ b/src/quartz_api/cmd/main.py
@@ -49,13 +49,14 @@ class ClearedInMemoryBackend(InMemoryBackend):
     """Custom in-memory cache backend that clears expired items."""
 
     async def periodic_clear_expired(self) -> None:
+        """Periodically clear expired cache items."""
         while True:
             async with self._lock:
                 now = self._now
                 for_del = tuple(k for k, v in self._store.items() if v.ttl_ts < now)
                 if len(for_del) > 0:
-                    log.debug(f'Clearing {len(for_del)} expired cache items, '
-                              f'from {self._store.keys()} cached items')
+                    log.debug(f"Clearing {len(for_del)} expired cache items, "
+                              f"from {self._store.keys()} cached items")
                     for k in for_del:
                         del self._store[k]
             # Lets sleep for 10 seconds before checking again if there are any expired items
@@ -148,12 +149,15 @@ async def _lifespan(server: FastAPI, conf: ConfigTree) -> AsyncGenerator[None]:
     # make sure cache is cleaned up every 10 seconds
     backend = FastAPICache.get_backend()
     if backend is not None and isinstance(backend, ClearedInMemoryBackend):
-        asyncio.create_task(backend.periodic_clear_expired())
+        clear_cache_periodically = asyncio.create_task(backend.periodic_clear_expired())
 
     yield
 
     if warm_task is not None:
         warm_task.cancel()
+
+    if clear_cache_periodically is not None:
+        clear_cache_periodically.cancel()
 
     gsp_id_map.clear()
     if grpc_channel:

--- a/src/quartz_api/cmd/main.py
+++ b/src/quartz_api/cmd/main.py
@@ -45,6 +45,21 @@ logging.getLogger("hpack").setLevel(logging.WARNING)
 
 static_dir = pathlib.Path(__file__).parent.parent / "static"
 
+class ClearedInMemoryBackend(InMemoryBackend):
+    """Custom in-memory cache backend that clears expired items."""
+
+    async def periodic_clear_expired(self) -> None:
+        while True:
+            async with self._lock:
+                now = self._now
+                for_del = tuple(k for k, v in self._store.items() if v.ttl_ts < now)
+                if len(for_del) > 0:
+                    log.debug(f'Clearing {len(for_del)} expired cache items, '
+                              f'from {self._store.keys()} cached items')
+                    for k in for_del:
+                        del self._store[k]
+            # Lets sleep for 10 seconds before checking again if there are any expired items
+            await asyncio.sleep(10)
 
 class GetHealthResponse(BaseModel):
     """Model for the health endpoint response."""
@@ -130,6 +145,11 @@ async def _lifespan(server: FastAPI, conf: ConfigTree) -> AsyncGenerator[None]:
     if "uk_national" in conf.get_string("api.routers"):
         warm_task = asyncio.create_task(_warm_forecast_all_cache(server))
 
+    # make sure cache is cleaned up every 10 seconds
+    backend = FastAPICache.get_backend()
+    if backend is not None and isinstance(backend, ClearedInMemoryBackend):
+        asyncio.create_task(backend.periodic_clear_expired())
+
     yield
 
     if warm_task is not None:
@@ -162,7 +182,7 @@ def _create_server(conf: ConfigTree) -> FastAPI:
         },
     )
 
-    FastAPICache.init(InMemoryBackend(), expire=120, prefix="fastapi-cache")
+    FastAPICache.init(ClearedInMemoryBackend(), expire=120, prefix="fastapi-cache")
 
     # Register rate limiter
     server.state.limiter = ratelimit.limiter

--- a/src/quartz_api/cmd/main.py
+++ b/src/quartz_api/cmd/main.py
@@ -59,8 +59,8 @@ class ClearedInMemoryBackend(InMemoryBackend):
                               f"from {self._store.keys()} cached items")
                     for k in for_del:
                         del self._store[k]
-            # Lets sleep for 10 seconds before checking again if there are any expired items
-            await asyncio.sleep(10)
+            # Lets sleep for 10 minutes before checking again if there are any expired items
+            await asyncio.sleep(600)
 
 class GetHealthResponse(BaseModel):
     """Model for the health endpoint response."""


### PR DESCRIPTION
# Pull Request

## Description

This removes old cached items if they are expired. This does not happen automatically (as I expected)

ref https://github.com/long2ice/fastapi-cache/issues/562

helps with https://github.com/openclimatefix/quartz-api/issues/259

## How Has This Been Tested?

- [x] Ci tests
- [x] ran it locally and saw cache getting removed
- [x] Test on dev, compared current version and new version. Hit API with about 1000s calls. 12:15 current version, causes 140 MB rise. New version 12:50 causes about 10MB rise

<img width="849" height="659" alt="Screenshot 2026-05-11 at 13 00 44" src="https://github.com/user-attachments/assets/e5f11490-5ad0-48b8-b87a-463df3de474a" />

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
