### PR TITLE
v1 NL final tweaks

### DIFF
--- a/src/quartz_api/internal/service/v1/cache.py
+++ b/src/quartz_api/internal/service/v1/cache.py
@@ -154,7 +154,7 @@ async def warm_v1_forecast_cache(
             energy_type.name.lower(),
             region_type,
         )
-        any_pgv = None
+        first_found_pgv = None
         last_updated: dt.datetime | None = None
         latest_init: dt.datetime | None = None
 
@@ -169,8 +169,8 @@ async def warm_v1_forecast_cache(
                 forecaster_name=rt.default_model,
             )
             if pgvs:
-                if any_pgv is None:
-                    any_pgv = pgvs[0]
+                if first_found_pgv is None:
+                    first_found_pgv = pgvs[0]
                 for pgv in pgvs:
                     if pgv.created_timestamp and (
                         last_updated is None or pgv.created_timestamp > last_updated
@@ -203,10 +203,10 @@ async def warm_v1_forecast_cache(
 
         meta = {
             "model_name": internal_to_api_name(
-                any_pgv.forecaster_name if any_pgv else None,
+                first_found_pgv.forecaster_name if first_found_pgv else None,
                 rt,
             ),
-            "model_version": any_pgv.forecaster_version if any_pgv else None,
+            "model_version": first_found_pgv.forecaster_version if first_found_pgv else None,
             "last_updated_utc": last_updated.isoformat() if last_updated else None,
             "latest_init_utc": latest_init.isoformat() if latest_init else None,
             "cache_updated_utc": dt.datetime.now(tz=dt.UTC).isoformat(),

--- a/src/quartz_api/internal/service/v1/cache.py
+++ b/src/quartz_api/internal/service/v1/cache.py
@@ -154,7 +154,9 @@ async def warm_v1_forecast_cache(
             energy_type.name.lower(),
             region_type,
         )
-        first_pgv = None
+        any_pgv = None
+        last_updated: dt.datetime | None = None
+        latest_init: dt.datetime | None = None
 
         for i, region in enumerate(regions):
             pgvs = await db.get_predicted_generation(
@@ -166,8 +168,18 @@ async def warm_v1_forecast_cache(
                 authdata={},
                 forecaster_name=rt.default_model,
             )
-            if pgvs and first_pgv is None:
-                first_pgv = pgvs[0]
+            if pgvs:
+                if any_pgv is None:
+                    any_pgv = pgvs[0]
+                for pgv in pgvs:
+                    if pgv.created_timestamp and (
+                        last_updated is None or pgv.created_timestamp > last_updated
+                    ):
+                        last_updated = pgv.created_timestamp
+                    if pgv.init_timestamp and (
+                        latest_init is None or pgv.init_timestamp > latest_init
+                    ):
+                        latest_init = pgv.init_timestamp
             values = [
                 {
                     "time": v.valid_timestamp.isoformat(),
@@ -189,16 +201,14 @@ async def warm_v1_forecast_cache(
             # yield to event loop; keeps live requests responsive during warm
             await asyncio.sleep(0.1)
 
-        created = first_pgv.created_timestamp if first_pgv else None
-        init = first_pgv.init_timestamp if first_pgv else None
         meta = {
             "model_name": internal_to_api_name(
-                first_pgv.forecaster_name if first_pgv else None,
+                any_pgv.forecaster_name if any_pgv else None,
                 rt,
             ),
-            "model_version": first_pgv.forecaster_version if first_pgv else None,
-            "created_utc": created.isoformat() if created else None,
-            "init_utc": init.isoformat() if init else None,
+            "model_version": any_pgv.forecaster_version if any_pgv else None,
+            "last_updated_utc": last_updated.isoformat() if last_updated else None,
+            "latest_init_utc": latest_init.isoformat() if latest_init else None,
             "cache_updated_utc": dt.datetime.now(tz=dt.UTC).isoformat(),
         }
         await backend.set(f"{base}:_meta", json.dumps(meta), expire=86400)

--- a/src/quartz_api/internal/service/v1/country_config.py
+++ b/src/quartz_api/internal/service/v1/country_config.py
@@ -338,7 +338,10 @@ COUNTRIES: dict[str, CountryConfig] = {
         ),
         generation_sources=(
             GenerationSource(
-                source="solar", name="nednl", label="NED NL Initial", slug="ned_nl"
+                source="solar",
+                name="nednl",
+                label="NED NL Initial",
+                slug="ned_nl",
             ),
         ),
     ),

--- a/src/quartz_api/internal/service/v1/country_config.py
+++ b/src/quartz_api/internal/service/v1/country_config.py
@@ -83,11 +83,21 @@ class RegionTypeConfig:
 
 @dataclass(frozen=True)
 class GenerationSource:
-    """Configuration for a generation source."""
+    """Configuration for a generation source.
+
+    `name` is the internal DP observer name. `slug` is the user-facing API name;
+    defaults to `name` when not set.
+    """
 
     source: str
     name: str
     label: str
+    slug: str | None = None
+
+    @property
+    def api_name(self) -> str:
+        """User-facing observer name used in API params."""
+        return self.slug if self.slug is not None else self.name
 
 
 @dataclass(frozen=True)
@@ -125,6 +135,13 @@ class CountryConfig:
             if gt.source == source:
                 return gt
         return None
+
+    def resolve_observer(self, api_name: str) -> str:
+        """Return the internal DP observer name for a user-facing API name."""
+        for gs in self.generation_sources:
+            if gs.api_name == api_name:
+                return gs.name
+        return api_name
 
 
 class FM:
@@ -312,7 +329,7 @@ COUNTRIES: dict[str, CountryConfig] = {
             ),
         ),
         generation_sources=(
-            GenerationSource(source="solar", name="nednl", label="NED NL Initial"),
+            GenerationSource(source="solar", name="nednl", label="NED NL Initial", slug="ned_nl"),
         ),
     ),
 }

--- a/src/quartz_api/internal/service/v1/country_config.py
+++ b/src/quartz_api/internal/service/v1/country_config.py
@@ -296,7 +296,7 @@ COUNTRIES: dict[str, CountryConfig] = {
             ),
         ),
         generation_sources=(
-            GenerationSource(source="solar", name="ned_nl", label="NED NL Initial"),
+            GenerationSource(source="solar", name="nednl", label="NED NL Initial"),
         ),
     ),
 }

--- a/src/quartz_api/internal/service/v1/country_config.py
+++ b/src/quartz_api/internal/service/v1/country_config.py
@@ -161,7 +161,9 @@ class FM:
         label="PVNet Intraday (ECMWF, Trend Adjusted)",
     )
     PVNET_SAT = ForecastModel(
-        name="pvnet_sat_only", label="PVNet Intraday (Satellite)", slug="pvnet_sat",
+        name="pvnet_sat_only",
+        label="PVNet Intraday (Satellite)",
+        slug="pvnet_sat",
     )
     PVNET_SAT_ADJUST = ForecastModel(
         name="pvnet_sat_only_adjust",
@@ -169,7 +171,9 @@ class FM:
         slug="pvnet_sat_adjust",
     )
     PVNET_UKV = ForecastModel(
-        name="pvnet_ukv_only", label="PVNet Intraday (Met Office)", slug="pvnet_ukv",
+        name="pvnet_ukv_only",
+        label="PVNet Intraday (Met Office)",
+        slug="pvnet_ukv",
     )
     PVNET_UKV_ADJUST = ForecastModel(
         name="pvnet_ukv_only_adjust",
@@ -178,7 +182,9 @@ class FM:
     )
     # GB — PVNet v2 (intraday)
     PVNET_INTRADAY = ForecastModel(
-        name="pvnet_v2", label="PVNet Intraday", slug="pvnet_intraday",
+        name="pvnet_v2",
+        label="PVNet Intraday",
+        slug="pvnet_intraday",
     )
     PVNET_INTRADAY_ADJUST = ForecastModel(
         name="pvnet_v2_adjust",
@@ -200,12 +206,14 @@ class FM:
     )
     # NL — uncurtailed (regional and national)
     NL_UNCURTAILED = ForecastModel(
-        name="nl_regional_ecmwf_mo_sat", label="Uncurtailed", slug="uncurtailed",
+        name="nl_regional_ecmwf_mo_sat",
+        label="ECMWF + Met Office + Satellite, Uncurtailed",
+        slug="ecmwf_mo_sat_uncurtailed",
     )
     NL_UNCURTAILED_ADJUST = ForecastModel(
         name="nl_regional_ecmwf_mo_sat_adjust",
-        label="Uncurtailed (Trend Adjusted)",
-        slug="uncurtailed_adjust",
+        label="ECMWF + Met Office + Satellite, Uncurtailed (Trend Adjusted)",
+        slug="ecmwf_mo_sat_uncurtailed_adjust",
     )
 
 
@@ -329,7 +337,9 @@ COUNTRIES: dict[str, CountryConfig] = {
             ),
         ),
         generation_sources=(
-            GenerationSource(source="solar", name="nednl", label="NED NL Initial", slug="ned_nl"),
+            GenerationSource(
+                source="solar", name="nednl", label="NED NL Initial", slug="ned_nl"
+            ),
         ),
     ),
 }

--- a/src/quartz_api/internal/service/v1/country_config.py
+++ b/src/quartz_api/internal/service/v1/country_config.py
@@ -127,10 +127,6 @@ class CountryConfig:
         return None
 
 
-def _m(name: str, label: str, slug: str | None = None) -> ForecastModel:
-    return ForecastModel(name=name, label=label, slug=slug)
-
-
 class FM:
     """All API-ready forecast models defined once — name, label, and slug in one place.
 
@@ -139,51 +135,59 @@ class FM:
     """
 
     # GB — blend
-    BLEND = _m("blend", "Blend")
-    BLEND_ADJUST = _m("blend_adjust", "Blend (Trend Adjusted)")
+    BLEND = ForecastModel(name="blend", label="Blend")
+    BLEND_ADJUST = ForecastModel(name="blend_adjust", label="Blend (Trend Adjusted)")
     # GB — PVNet single-source models
-    PVNET_ECMWF = _m("pvnet_ecmwf", "PVNet Intraday (ECMWF)")
-    PVNET_ECMWF_ADJUST = _m(
-        "pvnet_ecmwf_adjust",
-        "PVNet Intraday (ECMWF, Trend Adjusted)",
+    PVNET_ECMWF = ForecastModel(name="pvnet_ecmwf", label="PVNet Intraday (ECMWF)")
+    PVNET_ECMWF_ADJUST = ForecastModel(
+        name="pvnet_ecmwf_adjust",
+        label="PVNet Intraday (ECMWF, Trend Adjusted)",
     )
-    PVNET_SAT = _m("pvnet_sat_only", "PVNet Intraday (Satellite)", slug="pvnet_sat")
-    PVNET_SAT_ADJUST = _m(
-        "pvnet_sat_only_adjust",
-        "PVNet Intraday (Satellite, Trend Adjusted)",
+    PVNET_SAT = ForecastModel(
+        name="pvnet_sat_only", label="PVNet Intraday (Satellite)", slug="pvnet_sat",
+    )
+    PVNET_SAT_ADJUST = ForecastModel(
+        name="pvnet_sat_only_adjust",
+        label="PVNet Intraday (Satellite, Trend Adjusted)",
         slug="pvnet_sat_adjust",
     )
-    PVNET_UKV = _m("pvnet_ukv_only", "PVNet Intraday (Met Office)", slug="pvnet_ukv")
-    PVNET_UKV_ADJUST = _m(
-        "pvnet_ukv_only_adjust",
-        "PVNet Intraday (Met Office, Trend Adjusted)",
+    PVNET_UKV = ForecastModel(
+        name="pvnet_ukv_only", label="PVNet Intraday (Met Office)", slug="pvnet_ukv",
+    )
+    PVNET_UKV_ADJUST = ForecastModel(
+        name="pvnet_ukv_only_adjust",
+        label="PVNet Intraday (Met Office, Trend Adjusted)",
         slug="pvnet_ukv_adjust",
     )
     # GB — PVNet v2 (intraday)
-    PVNET_INTRADAY = _m("pvnet_v2", "PVNet Intraday", slug="pvnet_intraday")
-    PVNET_INTRADAY_ADJUST = _m(
-        "pvnet_v2_adjust",
-        "PVNet Intraday (Trend Adjusted)",
+    PVNET_INTRADAY = ForecastModel(
+        name="pvnet_v2", label="PVNet Intraday", slug="pvnet_intraday",
+    )
+    PVNET_INTRADAY_ADJUST = ForecastModel(
+        name="pvnet_v2_adjust",
+        label="PVNet Intraday (Trend Adjusted)",
         slug="pvnet_intraday_adjust",
     )
     # GB — PVNet day-ahead
-    PVNET_DAY_AHEAD = _m("pvnet_day_ahead", "PVNet Day Ahead")
-    PVNET_DAY_AHEAD_ADJUST = _m(
-        "pvnet_day_ahead_adjust",
-        "PVNet Day Ahead (Trend Adjusted)",
+    PVNET_DAY_AHEAD = ForecastModel(name="pvnet_day_ahead", label="PVNet Day Ahead")
+    PVNET_DAY_AHEAD_ADJUST = ForecastModel(
+        name="pvnet_day_ahead_adjust",
+        label="PVNet Day Ahead (Trend Adjusted)",
     )
     # NL — blend (slugs match GB blend slugs so API is consistent across countries)
-    NL_BLEND = _m("nl_blend", "Blend", slug="blend")
-    NL_BLEND_ADJUST = _m(
-        "nl_blend_adjust",
-        "Blend (Trend Adjusted)",
+    NL_BLEND = ForecastModel(name="nl_blend", label="Blend", slug="blend")
+    NL_BLEND_ADJUST = ForecastModel(
+        name="nl_blend_adjust",
+        label="Blend (Trend Adjusted)",
         slug="blend_adjust",
     )
     # NL — uncurtailed (regional and national)
-    NL_UNCURTAILED = _m("nl_regional_ecmwf_mo_sat", "Uncurtailed", slug="uncurtailed")
-    NL_UNCURTAILED_ADJUST = _m(
-        "nl_regional_ecmwf_mo_sat_adjust",
-        "Uncurtailed (Trend Adjusted)",
+    NL_UNCURTAILED = ForecastModel(
+        name="nl_regional_ecmwf_mo_sat", label="Uncurtailed", slug="uncurtailed",
+    )
+    NL_UNCURTAILED_ADJUST = ForecastModel(
+        name="nl_regional_ecmwf_mo_sat_adjust",
+        label="Uncurtailed (Trend Adjusted)",
         slug="uncurtailed_adjust",
     )
 

--- a/src/quartz_api/internal/service/v1/country_config.py
+++ b/src/quartz_api/internal/service/v1/country_config.py
@@ -179,6 +179,13 @@ class FM:
         "Blend (Trend Adjusted)",
         slug="blend_adjust",
     )
+    # NL — uncurtailed (regional and national)
+    NL_UNCURTAILED = _m("nl_regional_ecmwf_mo_sat", "Uncurtailed", slug="uncurtailed")
+    NL_UNCURTAILED_ADJUST = _m(
+        "nl_regional_ecmwf_mo_sat_adjust",
+        "Uncurtailed (Trend Adjusted)",
+        slug="uncurtailed_adjust",
+    )
 
 
 _GB_NATIONAL_FORECAST_MODELS = (
@@ -202,9 +209,14 @@ _GB_GSP_FORECAST_MODELS = (
     FM.PVNET_DAY_AHEAD,
 )
 
-_NL_NATIONAL_FORECAST_MODELS = (FM.NL_BLEND, FM.NL_BLEND_ADJUST)
+_NL_NATIONAL_FORECAST_MODELS = (
+    FM.NL_BLEND,
+    FM.NL_BLEND_ADJUST,
+    FM.NL_UNCURTAILED,
+    FM.NL_UNCURTAILED_ADJUST,
+)
 
-_NL_REGIONAL_FORECAST_MODELS = (FM.NL_BLEND,)
+_NL_REGIONAL_FORECAST_MODELS = (FM.NL_BLEND, FM.NL_UNCURTAILED)
 
 COUNTRIES: dict[str, CountryConfig] = {
     "GB": CountryConfig(

--- a/src/quartz_api/internal/service/v1/country_config.py
+++ b/src/quartz_api/internal/service/v1/country_config.py
@@ -296,7 +296,7 @@ COUNTRIES: dict[str, CountryConfig] = {
             ),
         ),
         generation_sources=(
-            GenerationSource(source="solar", name="nednl", label="NED NL Initial"),
+            GenerationSource(source="solar", name="ned_nl", label="NED NL Initial"),
         ),
     ),
 }

--- a/src/quartz_api/internal/service/v1/endpoint_types.py
+++ b/src/quartz_api/internal/service/v1/endpoint_types.py
@@ -97,11 +97,11 @@ ValidPeriodRegionType = Annotated[
 
 
 def _get_observer_sources() -> tuple[str, ...]:
-    """Extract all unique observer source names from country configs."""
+    """Extract all unique observer API names from country configs."""
     sources = set()
     for country_cfg in COUNTRIES.values():
         for gen_type in country_cfg.generation_sources:
-            sources.add(gen_type.name)
+            sources.add(gen_type.api_name)
     return tuple(sorted(sources))
 
 

--- a/src/quartz_api/internal/service/v1/endpoint_types.py
+++ b/src/quartz_api/internal/service/v1/endpoint_types.py
@@ -304,8 +304,8 @@ class ForecastResponse(BaseModel):
     capacity_kW: float
     model_name: str | None = None
     model_version: str | None = None
-    created_utc: dt.datetime | None = None
-    init_utc: dt.datetime | None = None
+    last_updated_utc: dt.datetime | None = None
+    latest_init_utc: dt.datetime | None = None
     horizon_minutes: int | None = None
     values: list[ForecastValue]
 
@@ -341,8 +341,8 @@ class ForecastSnapshot(BaseModel):
     time: dt.datetime
     model_name: str | None = None
     model_version: str | None = None
-    created_utc: dt.datetime | None = None
-    init_utc: dt.datetime | None = None
+    last_updated_utc: dt.datetime | None = None
+    latest_init_utc: dt.datetime | None = None
     values: list[RegionForecastValue]
 
 
@@ -376,8 +376,8 @@ class RegionForecastMatrix(BaseModel):
 
     model_name: str | None = None
     model_version: str | None = None
-    created_utc: dt.datetime | None = None
-    init_utc: dt.datetime | None = None
+    last_updated_utc: dt.datetime | None = None
+    latest_init_utc: dt.datetime | None = None
     cache_updated_utc: dt.datetime | None = None
     times: list[dt.datetime]
     regions: list[RegionForecast]

--- a/src/quartz_api/internal/service/v1/routes/discovery.py
+++ b/src/quartz_api/internal/service/v1/routes/discovery.py
@@ -98,7 +98,7 @@ async def get_countries(
                     for rt in cfg.region_types
                 ],
                 generation_sources=[
-                    GenerationSource(source=gs.source, name=gs.name, label=gs.label)
+                    GenerationSource(source=gs.source, name=gs.api_name, label=gs.label)
                     for gs in cfg.generation_sources
                 ],
             ),
@@ -164,4 +164,8 @@ async def get_generation_sources(
     generation data — for example PV_Live in-day estimates vs finalised day-after values.
     Use the `name` field as the `observer` parameter on generation endpoints.
     """
-    return [s for s in country.generation_sources if s.source == source.name.lower()]
+    return [
+        GenerationSource(source=s.source, name=s.api_name, label=s.label)
+        for s in country.generation_sources
+        if s.source == source.name.lower()
+    ]

--- a/src/quartz_api/internal/service/v1/routes/discovery.py
+++ b/src/quartz_api/internal/service/v1/routes/discovery.py
@@ -35,7 +35,6 @@ async def get_sources(
 
     Returns the set of energy source types supported by the API. Use the `name` value
     as the `{source}` path segment in all other v1 routes (e.g. `/v1/GB/solar/regions`).
-    Cached for 1 minute.
     """
     return [
         Source(name="solar", label="Solar"),
@@ -64,7 +63,7 @@ async def get_countries(
     - **capacity_kW** and **centroid** — installed capacity and geographic centre.
 
     Use the `country` value (e.g. `GB`, `NL`) as the `{country}` path segment in all other
-    v1 routes. Cached for 1 minute.
+    v1 routes.
     """
     nations = await db.get_locations(
         energy_type=models.EnergyType.SOLAR,
@@ -131,8 +130,6 @@ async def get_region_types(
     - **forecast_models** — the models available for that region type, with the model
       `name` used as the `model` parameter on forecast endpoints. The first listed model
       is the default.
-
-    Cached for 1 minute.
     """
     return [
         RegionType(
@@ -166,6 +163,5 @@ async def get_generation_sources(
     Generation sources represent the different observers that produce actual (measured)
     generation data — for example PV_Live in-day estimates vs finalised day-after values.
     Use the `name` field as the `observer` parameter on generation endpoints.
-    Cached for 1 minute.
     """
     return [s for s in country.generation_sources if s.source == source.name.lower()]

--- a/src/quartz_api/internal/service/v1/routes/forecasts.py
+++ b/src/quartz_api/internal/service/v1/routes/forecasts.py
@@ -57,6 +57,7 @@ router = APIRouter(tags=["Forecasts"])
     "/{country}/{source}/regions/{region}/forecast",
     status_code=status.HTTP_200_OK,
     response_model=ForecastResponse,
+    response_model_exclude_none=True,
 )
 @cache(key_builder=key_builder, expire=60)
 async def get_forecast(
@@ -78,7 +79,7 @@ async def get_forecast(
             "Use to retrieve the forecast 'as it was' at a point in time."
         ),
     ),
-    forecast_horizon_minutes: int | None = Query(
+    horizon_minutes: int | None = Query(
         None,
         description=(
             "Forecast horizon filter in minutes. For example, `60` returns only "
@@ -131,7 +132,7 @@ async def get_forecast(
                 location_type=location_type,
                 authdata={},  # TODO: add auth when loosed on DP side
                 created_cutoff=creation_limit_utc,
-                forecast_horizon_minutes=forecast_horizon_minutes or 0,
+                forecast_horizon_minutes=horizon_minutes or 0,
                 forecaster_name=model,
             ),
         )
@@ -142,9 +143,9 @@ async def get_forecast(
         capacity_kW=first.capacity_kilowatts if first else 0.0,
         model_name=internal_to_api_name(first.forecaster_name if first else None, rt),
         model_version=first.forecaster_version if first else None,
-        created_utc=first.created_timestamp if first else None,
-        init_utc=first.init_timestamp if first else None,
-        horizon_minutes=forecast_horizon_minutes,
+        last_updated_utc=first.created_timestamp if first else None,
+        latest_init_utc=first.init_timestamp if first else None,
+        horizon_minutes=horizon_minutes,
         values=[
             ForecastValue(
                 time=v.valid_timestamp,
@@ -173,7 +174,7 @@ async def get_forecast_last_updated_timestamp(
 ) -> dt.datetime:
     """Return the creation time of the most recent forecast for a region.
 
-    Queries the forecast within ±30 minutes of now and returns the `created_utc`
+    Queries the forecast within ±30 minutes of now and returns the `last_updated_utc`
     of the most recent run. Useful for monitoring freshness or driving "last updated"
     indicators in a UI. Cached for 10 seconds.
     """
@@ -288,8 +289,8 @@ async def get_forecasts_at_time(
         time=snapshot_time,
         model_name=internal_to_api_name(first.forecaster_name if first else None, rt),
         model_version=first.forecaster_version if first else None,
-        created_utc=first.created_timestamp if first else None,
-        init_utc=first.init_timestamp if first else None,
+        last_updated_utc=first.created_timestamp if first else None,
+        latest_init_utc=first.init_timestamp if first else None,
         values=[
             RegionForecastValue(
                 region_name=region_names.get(v.location_uuid, ""),

--- a/src/quartz_api/internal/service/v1/routes/forecasts.py
+++ b/src/quartz_api/internal/service/v1/routes/forecasts.py
@@ -409,7 +409,8 @@ async def get_forecasts_period(
     if region_names is not None:
         name_set = {n.lower() for n in region_names}
         regions = [
-            r for r in regions
+            r
+            for r in regions
             if r.name.lower() in name_set
             or location_display_name(r, country).lower() in name_set
         ]

--- a/src/quartz_api/internal/service/v1/routes/forecasts.py
+++ b/src/quartz_api/internal/service/v1/routes/forecasts.py
@@ -95,7 +95,6 @@ async def get_forecast(
 
     By default the window runs from **now** to **48 hours ahead**. Use `start_utc` /
     `end_utc` to override. Historical data is available up to 1 year back.
-    Cached for 1 minute.
     """
     is_intraday_only = not check_country_access(auth, country)
     resolved_id = await resolve_region_id(region, country, source, db)
@@ -176,7 +175,7 @@ async def get_forecast_last_updated_timestamp(
 
     Queries the forecast within ±30 minutes of now and returns the `last_updated_utc`
     of the most recent run. Useful for monitoring freshness or driving "last updated"
-    indicators in a UI. Cached for 10 seconds.
+    indicators in a UI.
     """
     is_intraday_only = not check_country_access(auth, country)
     resolved_id = await resolve_region_id(region, country, source, db)
@@ -239,7 +238,7 @@ async def get_forecasts_at_time(
 
     Returns a `ForecastSnapshot` — a single point in time with one forecast value per
     region. Useful for rendering a map of forecast output across an entire country at
-    a glance. Cached for 2 minutes.
+    a glance.
     """
     is_intraday_only = not check_country_access(auth, country)
     nation = await resolve_nation(db, source, country, auth)

--- a/src/quartz_api/internal/service/v1/routes/forecasts.py
+++ b/src/quartz_api/internal/service/v1/routes/forecasts.py
@@ -408,7 +408,11 @@ async def get_forecasts_period(
 
     if region_names is not None:
         name_set = {n.lower() for n in region_names}
-        regions = [r for r in regions if r.name.lower() in name_set]
+        regions = [
+            r for r in regions
+            if r.name.lower() in name_set
+            or location_display_name(r, country).lower() in name_set
+        ]
 
     raw_list = await asyncio.gather(*[backend.get(f"{base}:{r.uuid}") for r in regions])
     all_region_data: list[tuple] = []

--- a/src/quartz_api/internal/service/v1/routes/generation.py
+++ b/src/quartz_api/internal/service/v1/routes/generation.py
@@ -86,8 +86,6 @@ async def get_generation(
     NL currently has one observer for solar:
 
     - **ned_nl** — NED NL estimated solar generation for provinces / national including curtailment.
-
-    Cached for 1 minute.
     """
     check_country_access(auth, country)
     resolved_id = await resolve_region_id(region, country, source, db)
@@ -163,7 +161,7 @@ async def get_generation_at_timestamp(
 
     Returns a `GenerationSnapshot` — a single point in time with one observed generation
     value per region. Useful for rendering a map of current solar output across an entire
-    country. Cached for 2 minutes.
+    country.
 
     When `time_utc` is omitted the endpoint resolves the most recent available timestamp
     automatically (looking back up to 6 hours) rather than using "now", which would

--- a/src/quartz_api/internal/service/v1/routes/generation.py
+++ b/src/quartz_api/internal/service/v1/routes/generation.py
@@ -85,9 +85,10 @@ async def get_generation(
 
     NL currently has one observer for solar:
 
-    - **nednl** — NED NL estimated solar generation for provinces / national including curtailment.
+    - **ned_nl** — NED NL estimated solar generation for provinces / national including curtailment.
     """
     check_country_access(auth, country)
+    dp_observer = country.resolve_observer(observer)
     resolved_id = await resolve_region_id(region, country, source, db)
 
     locs = await db.get_locations(
@@ -117,7 +118,7 @@ async def get_generation(
                 window_end=chunk_end,
                 energy_type=source,
                 location_type=location_type,
-                observer_name=observer,
+                observer_name=dp_observer,
                 authdata={},  # TODO: add auth when loosed on DP side
             ),
         )
@@ -168,6 +169,7 @@ async def get_generation_at_timestamp(
     rarely have data.
     """
     check_country_access(auth, country)
+    dp_observer = country.resolve_observer(observer)
     nation = await resolve_nation(db, source, country, auth)
 
     rt = country.get_region_type(region_type)
@@ -211,7 +213,7 @@ async def get_generation_at_timestamp(
             window_end=now,
             energy_type=source,
             location_type=location_type,
-            observer_name=observer,
+            observer_name=dp_observer,
             authdata={},
         )
         snapshot_time = (
@@ -227,7 +229,7 @@ async def get_generation_at_timestamp(
         location_uuids=[to_uuid(r.uuid) for r in regions],
         snapshot_timestamp_utc=snapshot_time,
         energy_type=source,
-        observer_name=observer,
+        observer_name=dp_observer,
         authdata={},
     )
 
@@ -312,7 +314,9 @@ async def get_generation_period(
             ),
         )
     valid_observers = {
-        gs.name for gs in country.generation_sources if gs.source == source.name.lower()
+        gs.api_name
+        for gs in country.generation_sources
+        if gs.source == source.name.lower()
     }
     if observer not in valid_observers:
         raise HTTPException(
@@ -322,6 +326,7 @@ async def get_generation_period(
                 f"{country.code} {source.name.lower()}. Available: {sorted(valid_observers)}"
             ),
         )
+    dp_observer = country.resolve_observer(observer)
 
     win_start, win_end = timeseries_window(start_utc, end_utc)
     validate_window(win_start, win_end)
@@ -333,7 +338,7 @@ async def get_generation_period(
         country.code,
         source.name.lower(),
         region_type,
-        observer,
+        dp_observer,
     )
 
     raw_meta = await backend.get(f"{base}:_meta")
@@ -361,7 +366,8 @@ async def get_generation_period(
     if region_names is not None:
         name_set = {n.lower() for n in region_names}
         regions = [
-            r for r in regions
+            r
+            for r in regions
             if r.name.lower() in name_set
             or location_display_name(r, country).lower() in name_set
         ]
@@ -414,7 +420,8 @@ async def refresh_generation_cache(
     """
     if "ocf:admin" not in auth.get("permissions", []):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
-    flag_key = f"{source.name.lower()}:{country.code}:{region_type}:{observer}"
+    dp_observer = country.resolve_observer(observer)
+    flag_key = f"{source.name.lower()}:{country.code}:{region_type}:{dp_observer}"
     if generation_cache_warming.get(flag_key):
         return Response(status_code=202, content="Cache warm already in progress")
     background_tasks.add_task(
@@ -423,6 +430,6 @@ async def refresh_generation_cache(
         source,
         country.code,
         region_type,
-        observer,
+        dp_observer,
     )
     return Response(status_code=202, content="Cache refresh triggered")

--- a/src/quartz_api/internal/service/v1/routes/generation.py
+++ b/src/quartz_api/internal/service/v1/routes/generation.py
@@ -362,7 +362,11 @@ async def get_generation_period(
 
     if region_names is not None:
         name_set = {n.lower() for n in region_names}
-        regions = [r for r in regions if r.name.lower() in name_set]
+        regions = [
+            r for r in regions
+            if r.name.lower() in name_set
+            or location_display_name(r, country).lower() in name_set
+        ]
 
     raw_list = await asyncio.gather(*[backend.get(f"{base}:{r.uuid}") for r in regions])
     all_region_data: list[tuple] = []

--- a/src/quartz_api/internal/service/v1/routes/generation.py
+++ b/src/quartz_api/internal/service/v1/routes/generation.py
@@ -85,7 +85,7 @@ async def get_generation(
 
     NL currently has one observer for solar:
 
-    - **ned_nl** — NED NL estimated solar generation for provinces / national including curtailment.
+    - **nednl** — NED NL estimated solar generation for provinces / national including curtailment.
     """
     check_country_access(auth, country)
     resolved_id = await resolve_region_id(region, country, source, db)

--- a/src/quartz_api/internal/service/v1/routes/regions.py
+++ b/src/quartz_api/internal/service/v1/routes/regions.py
@@ -58,8 +58,6 @@ async def get_country_regions(
     - `region_type` — restricts results to one granularity level (e.g. `gsp`).
     - `parent` — returns the direct children of the specified parent region.
     - `name` — case-insensitive substring search across region names.
-
-    Cached for 1 minute.
     """
     check_country_access(auth, country)
     nation = await resolve_nation(db, source, country, auth)
@@ -158,7 +156,7 @@ async def get_region(
     """Get details for a specific region.
 
     Returns a `RegionDetail` object with the region's name, type, installed
-    capacity, centroid, and any available metadata fields. Cached for 1 minute.
+    capacity, centroid, and any available metadata fields.
     """
     check_country_access(auth, country)
     resolved_id = await resolve_region_id(region, country, source, db)

--- a/src/quartz_api/internal/service/v1/test_router.py
+++ b/src/quartz_api/internal/service/v1/test_router.py
@@ -726,7 +726,7 @@ async def test_get_generation_period_wrong_country_observer_returns_400(
         "/v1/NL/solar/generation/period?region_type=province&observer=pvlive_in_day",
     )
     assert resp.status_code == 400
-    assert "nednl" in resp.json()["detail"]
+    assert "ned_nl" in resp.json()["detail"]
 
 
 # ---------------------------------------------------------------------------
@@ -1665,11 +1665,11 @@ async def test_nl_forecast_invalid_model_400(nl_client: AsyncClient) -> None:
 
 @pytest.mark.anyio
 async def test_nl_generation_sources(nl_client: AsyncClient) -> None:
-    """NL generation sources discovery is public and includes nednl."""
+    """NL generation sources discovery is public and includes ned_nl."""
     resp = await nl_client.get("/v1/NL/solar/generation-sources")
     assert resp.status_code == 200
     names = [s["name"] for s in resp.json()]
-    assert "nednl" in names
+    assert "ned_nl" in names
 
 
 @pytest.mark.anyio

--- a/src/quartz_api/internal/service/v1/test_router.py
+++ b/src/quartz_api/internal/service/v1/test_router.py
@@ -254,6 +254,48 @@ async def trial_client() -> AsyncGenerator[AsyncClient, None]:
         yield ac
 
 
+_FIXED_NL_PROVINCE_UUID = uuid4()
+_NL_PROVINCE_INTERNAL_NAME = "nl_region_2_friesland"
+_NL_PROVINCE_DISPLAY_NAME = "friesland"
+
+
+class FixedNLProvinceClient(NationNameStorageClient):
+    """NL client that returns a stable UUID for the Friesland province.
+
+    Allows cache-key tests that verify display-name filtering works for NL.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("nl_national")
+
+    async def get_locations(  # type: ignore[override]
+        self,
+        energy_type: models.EnergyType,
+        location_type: models.LocationType | None,
+        authdata: dict,
+        location_uuid: UUID | None = None,
+        enclosing_location_uuid: UUID | None = None,
+    ) -> list[models.Location]:
+        if location_type == models.LocationType.REGION:
+            return [
+                models.Location(
+                    uuid=_FIXED_NL_PROVINCE_UUID,
+                    name=_NL_PROVINCE_INTERNAL_NAME,
+                    latitude=53.0,
+                    longitude=5.8,
+                    capacity_kilowatts=500_000,
+                    location_type=models.LocationType.REGION,
+                ),
+            ]
+        return await super().get_locations(
+            energy_type=energy_type,
+            location_type=location_type,
+            authdata={},
+            location_uuid=location_uuid,
+            enclosing_location_uuid=enclosing_location_uuid,
+        )
+
+
 @pytest_asyncio.fixture
 async def nl_client() -> AsyncGenerator[AsyncClient, None]:
     """Test client with NL read permission backed by NationNameStorageClient."""
@@ -1686,3 +1728,55 @@ def test_country_config_intraday_default_in_intraday_models() -> None:
                 f"{country_code}/{rt.type}: intraday_default_model "
                 f"'{rt.intraday_default_model.api_name}' is not in intraday_models"
             )
+
+
+# ---------------------------------------------------------------------------
+# NL display-name filter
+
+
+@pytest_asyncio.fixture
+async def nl_province_client() -> AsyncGenerator[AsyncClient, None]:
+    """NL client backed by FixedNLProvinceClient for display-name filter tests."""
+    FastAPICache.init(InMemoryBackend(), prefix="test")
+    app = _make_app(FixedNLProvinceClient(), ["read:nl"])
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        yield ac
+
+
+@pytest.mark.anyio
+async def test_nl_forecast_period_display_name_filter(
+    nl_province_client: AsyncClient,
+) -> None:
+    """region_names filter matches NL province display names, not internal DP names."""
+    prefix = FastAPICache.get_prefix()
+    backend = FastAPICache.get_backend()
+    base = f"{prefix}:v1:period:NL:solar:province"
+    await backend.set(
+        f"{base}:_meta",
+        json.dumps({"model_name": "nl_blend_adjust", "model_version": "1", "created_utc": None, "init_utc": None, "cache_updated_utc": None}).encode(),
+        expire=3600,
+    )
+    await backend.set(
+        f"{base}:{_FIXED_NL_PROVINCE_UUID}",
+        json.dumps([{"time": "2026-01-01T12:00:00+00:00", "power_kW": 100.0, "plevels_kW": {}}]).encode(),
+        expire=3600,
+    )
+
+    # Filter by display name — should match despite internal name being different.
+    resp = await nl_province_client.get(
+        f"/v1/NL/solar/forecasts/period?region_type=province&region_names={_NL_PROVINCE_DISPLAY_NAME}",
+    )
+    assert resp.status_code == 200
+    regions = resp.json()["regions"]
+    assert len(regions) == 1
+    assert regions[0]["region_name"] == _NL_PROVINCE_DISPLAY_NAME
+
+    # Filter by internal DP name — should also match (fallback).
+    resp2 = await nl_province_client.get(
+        f"/v1/NL/solar/forecasts/period?region_type=province&region_names={_NL_PROVINCE_INTERNAL_NAME}",
+    )
+    assert resp2.status_code == 200
+    assert len(resp2.json()["regions"]) == 1

--- a/src/quartz_api/internal/service/v1/test_router.py
+++ b/src/quartz_api/internal/service/v1/test_router.py
@@ -1756,12 +1756,22 @@ async def test_nl_forecast_period_display_name_filter(
     base = f"{prefix}:v1:period:NL:solar:province"
     await backend.set(
         f"{base}:_meta",
-        json.dumps({"model_name": "nl_blend_adjust", "model_version": "1", "last_updated_utc": None, "latest_init_utc": None, "cache_updated_utc": None}).encode(),
+        json.dumps(
+            {
+                "model_name": "nl_blend_adjust",
+                "model_version": "1",
+                "last_updated_utc": None,
+                "latest_init_utc": None,
+                "cache_updated_utc": None,
+            },
+        ).encode(),
         expire=3600,
     )
     await backend.set(
         f"{base}:{_FIXED_NL_PROVINCE_UUID}",
-        json.dumps([{"time": "2026-01-01T12:00:00+00:00", "power_kW": 100.0, "plevels_kW": {}}]).encode(),
+        json.dumps(
+            [{"time": "2026-01-01T12:00:00+00:00", "power_kW": 100.0, "plevels_kW": {}}],
+        ).encode(),
         expire=3600,
     )
 

--- a/src/quartz_api/internal/service/v1/test_router.py
+++ b/src/quartz_api/internal/service/v1/test_router.py
@@ -726,7 +726,7 @@ async def test_get_generation_period_wrong_country_observer_returns_400(
         "/v1/NL/solar/generation/period?region_type=province&observer=pvlive_in_day",
     )
     assert resp.status_code == 400
-    assert "ned_nl" in resp.json()["detail"]
+    assert "nednl" in resp.json()["detail"]
 
 
 # ---------------------------------------------------------------------------
@@ -1665,11 +1665,11 @@ async def test_nl_forecast_invalid_model_400(nl_client: AsyncClient) -> None:
 
 @pytest.mark.anyio
 async def test_nl_generation_sources(nl_client: AsyncClient) -> None:
-    """NL generation sources discovery is public and includes ned_nl."""
+    """NL generation sources discovery is public and includes nednl."""
     resp = await nl_client.get("/v1/NL/solar/generation-sources")
     assert resp.status_code == 200
     names = [s["name"] for s in resp.json()]
-    assert "ned_nl" in names
+    assert "nednl" in names
 
 
 @pytest.mark.anyio

--- a/src/quartz_api/internal/service/v1/test_router.py
+++ b/src/quartz_api/internal/service/v1/test_router.py
@@ -1775,7 +1775,7 @@ async def test_nl_forecast_period_display_name_filter(
                     "time": "2026-01-01T12:00:00+00:00",
                     "power_kW": 100.0,
                     "plevels_kW": {},
-                }
+                },
             ],
         ).encode(),
         expire=3600,

--- a/src/quartz_api/internal/service/v1/test_router.py
+++ b/src/quartz_api/internal/service/v1/test_router.py
@@ -259,7 +259,7 @@ _NL_PROVINCE_INTERNAL_NAME = "nl_region_2_friesland"
 _NL_PROVINCE_DISPLAY_NAME = "friesland"
 
 
-class FixedNLProvinceClient(NationNameStorageClient):
+class NLProvinceClient(NationNameStorageClient):
     """NL client that returns a stable UUID for the Friesland province.
 
     Allows cache-key tests that verify display-name filtering works for NL.
@@ -1736,9 +1736,9 @@ def test_country_config_intraday_default_in_intraday_models() -> None:
 
 @pytest_asyncio.fixture
 async def nl_province_client() -> AsyncGenerator[AsyncClient, None]:
-    """NL client backed by FixedNLProvinceClient for display-name filter tests."""
+    """NL client backed by NLProvinceClient for display-name filter tests."""
     FastAPICache.init(InMemoryBackend(), prefix="test")
-    app = _make_app(FixedNLProvinceClient(), ["read:nl"])
+    app = _make_app(NLProvinceClient(), ["read:nl"])
     async with AsyncClient(
         transport=ASGITransport(app=app),
         base_url="http://test",

--- a/src/quartz_api/internal/service/v1/test_router.py
+++ b/src/quartz_api/internal/service/v1/test_router.py
@@ -1770,7 +1770,13 @@ async def test_nl_forecast_period_display_name_filter(
     await backend.set(
         f"{base}:{_FIXED_NL_PROVINCE_UUID}",
         json.dumps(
-            [{"time": "2026-01-01T12:00:00+00:00", "power_kW": 100.0, "plevels_kW": {}}],
+            [
+                {
+                    "time": "2026-01-01T12:00:00+00:00",
+                    "power_kW": 100.0,
+                    "plevels_kW": {},
+                }
+            ],
         ).encode(),
         expire=3600,
     )

--- a/src/quartz_api/internal/service/v1/test_router.py
+++ b/src/quartz_api/internal/service/v1/test_router.py
@@ -386,8 +386,8 @@ async def _set_forecast_meta() -> None:
     meta = {
         "model_name": "blend",
         "model_version": "1.0.0",
-        "created_utc": now.isoformat(),
-        "init_utc": now.isoformat(),
+        "last_updated_utc": now.isoformat(),
+        "latest_init_utc": now.isoformat(),
     }
     prefix = FastAPICache.get_prefix()
     backend = FastAPICache.get_backend()
@@ -563,7 +563,7 @@ async def test_get_region_forecast(client: AsyncClient) -> None:
     assert "capacity_kW" in body
     assert "values" in body
     assert "model_name" in body
-    assert "init_utc" in body
+    assert "latest_init_utc" in body
 
 
 @pytest.mark.anyio
@@ -1065,11 +1065,11 @@ async def test_get_region_forecast_creation_limit_utc(client: AsyncClient) -> No
 
 
 @pytest.mark.anyio
-async def test_get_region_forecast_horizon_minutes(client: AsyncClient) -> None:
-    """forecast_horizon_minutes passes through to backend — endpoint returns 200."""
+async def test_get_region_forecast_horizon_minutes_param(client: AsyncClient) -> None:
+    """horizon_minutes passes through to backend — endpoint returns 200."""
     region_id = str(uuid4())
     resp = await client.get(
-        f"/v1/GB/solar/regions/{region_id}/forecast?forecast_horizon_minutes=1440",
+        f"/v1/GB/solar/regions/{region_id}/forecast?horizon_minutes=1440",
     )
     assert resp.status_code == 200
 
@@ -1756,7 +1756,7 @@ async def test_nl_forecast_period_display_name_filter(
     base = f"{prefix}:v1:period:NL:solar:province"
     await backend.set(
         f"{base}:_meta",
-        json.dumps({"model_name": "nl_blend_adjust", "model_version": "1", "created_utc": None, "init_utc": None, "cache_updated_utc": None}).encode(),
+        json.dumps({"model_name": "nl_blend_adjust", "model_version": "1", "last_updated_utc": None, "latest_init_utc": None, "cache_updated_utc": None}).encode(),
         expire=3600,
     )
     await backend.set(


### PR DESCRIPTION
# Pull Request

## Description

- **NL province period endpoints** — region name filter was matching against internal DP names instead of display names, so province filters returned no results
- **Fix naming mismatch** — use `nednl` everywhere instead of mix of `ned_nl`
- **`last_updated_utc` / `latest_init_utc` in `/forecasts/period`** — cache warm was capturing timestamps from the first pgv seen; now takes the max across all regions so metadata reflects the most recent run, not the earliest
- **Rename `created_utc` → `last_updated_utc`, `init_utc` → `latest_init_utc`** — old names implied these described all values in the stitched series, not just the latest run
- **Rename `forecast_horizon_minutes` → `horizon_minutes`** — shorter; omitted from response when not set rather than returning `null`
- **NL uncurtailed forecast models** — added `ecmwf_mo_sat_uncurtailed` / `ecmwf_mo_sat_uncurtailed_adjust` slugs for `nl_regional_ecmwf_mo_sat` to NL national and regional model lists (unadjusted-only for regional)
- **Remove cache TTL disclosures** from v1 route docstrings
- **Inline `ForecastModel` in `FM` class** — remove `_m` shorthand helper
- **Rename `nednl` observer → `ned_nl`** — user-facing API name now uses underscore convention; internal DP observer name (`nednl`) is preserved via a new `slug` field on `GenerationSource`, consistent with the existing `ForecastModel` pattern
- **Rename `FixedNLProvinceClient` → `NLProvinceClient`** in tests


Fixes #310 (again)

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [x] Locally (manual checks)
- [x] Unit tests (local / CI)

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
