### PR TITLE
fix(national): Prevent error including metadata on empty response

### DIFF
--- a/src/quartz_api/internal/service/uk_national/national_router.py
+++ b/src/quartz_api/internal/service/uk_national/national_router.py
@@ -201,7 +201,7 @@ async def get_national_forecast(
         for v in all_pgvs
     ]
 
-    if not include_metadata:
+    if not include_metadata or len(out) == 0:
         return out
 
     else:


### PR DESCRIPTION
Fixes a bug whereby an empty response from the backend would crash if include_metadata was set to true.