### PR TITLE
v1 Beta Fixes (time_utc consistency, hide missing p-levels)

### DIFF
--- a/src/quartz_api/internal/service/v1/cache.py
+++ b/src/quartz_api/internal/service/v1/cache.py
@@ -182,7 +182,7 @@ async def warm_v1_forecast_cache(
                         latest_init = pgv.init_timestamp
             values = [
                 {
-                    "time": v.valid_timestamp.isoformat(),
+                    "time_utc": v.valid_timestamp.isoformat(),
                     "power_kW": v.power_kilowatts,
                     "plevels_kW": v.plevels_kilowatts,
                 }
@@ -307,7 +307,7 @@ async def warm_v1_generation_cache(
             )
             values = [
                 {
-                    "time": v.valid_timestamp.isoformat(),
+                    "time_utc": v.valid_timestamp.isoformat(),
                     "power_kW": v.power_kilowatts,
                 }
                 for v in agvs

--- a/src/quartz_api/internal/service/v1/cache.py
+++ b/src/quartz_api/internal/service/v1/cache.py
@@ -206,7 +206,9 @@ async def warm_v1_forecast_cache(
                 first_found_pgv.forecaster_name if first_found_pgv else None,
                 rt,
             ),
-            "model_version": first_found_pgv.forecaster_version if first_found_pgv else None,
+            "model_version": (
+                first_found_pgv.forecaster_version if first_found_pgv else None
+            ),
             "last_updated_utc": last_updated.isoformat() if last_updated else None,
             "latest_init_utc": latest_init.isoformat() if latest_init else None,
             "cache_updated_utc": dt.datetime.now(tz=dt.UTC).isoformat(),
@@ -290,6 +292,8 @@ async def warm_v1_generation_cache(
             region_type,
             observer,
         )
+        gs = next((gs for gs in cfg.generation_sources if gs.name == observer), None)
+        api_observer_name = gs.api_name if gs else observer
 
         for i, region in enumerate(regions):
             agvs = await db.get_actual_generation(
@@ -323,7 +327,7 @@ async def warm_v1_generation_cache(
             await asyncio.sleep(0.1)
 
         meta = {
-            "observer_name": observer,
+            "observer_name": api_observer_name,
             "cache_updated_utc": dt.datetime.now(tz=dt.UTC).isoformat(),
         }
         await backend.set(f"{base}:_meta", json.dumps(meta), expire=86400)

--- a/src/quartz_api/internal/service/v1/endpoint_types.py
+++ b/src/quartz_api/internal/service/v1/endpoint_types.py
@@ -292,7 +292,7 @@ class RegionDetail(RegionSummary):
 class ForecastValue(BaseModel):
     """A single forecast value at a point in time."""
 
-    time: dt.datetime
+    time_utc: dt.datetime
     power_kW: float
     plevels_kW: dict[str, float] = Field(default_factory=dict)
 
@@ -313,7 +313,7 @@ class ForecastResponse(BaseModel):
 class GenerationValue(BaseModel):
     """A single observed generation value at a point in time."""
 
-    time: dt.datetime
+    time_utc: dt.datetime
     power_kW: float
 
 
@@ -338,7 +338,7 @@ class RegionForecastValue(BaseModel):
 class ForecastSnapshot(BaseModel):
     """Snapshot forecast across all regions at a single point in time."""
 
-    time: dt.datetime
+    time_utc: dt.datetime
     model_name: str | None = None
     model_version: str | None = None
     last_updated_utc: dt.datetime | None = None
@@ -357,7 +357,7 @@ class RegionGenerationValue(BaseModel):
 class GenerationSnapshot(BaseModel):
     """Snapshot observed generation across all regions at a single point in time."""
 
-    time: dt.datetime
+    time_utc: dt.datetime
     observer_name: str | None = None
     values: list[RegionGenerationValue]
 
@@ -379,7 +379,7 @@ class RegionForecastMatrix(BaseModel):
     last_updated_utc: dt.datetime | None = None
     latest_init_utc: dt.datetime | None = None
     cache_updated_utc: dt.datetime | None = None
-    times: list[dt.datetime]
+    times_utc: list[dt.datetime]
     regions: list[RegionForecast]
 
 
@@ -396,5 +396,5 @@ class RegionGenerationMatrix(BaseModel):
 
     observer_name: str | None = None
     cache_updated_utc: dt.datetime | None = None
-    times: list[dt.datetime]
+    times_utc: list[dt.datetime]
     regions: list[RegionGeneration]

--- a/src/quartz_api/internal/service/v1/endpoint_types.py
+++ b/src/quartz_api/internal/service/v1/endpoint_types.py
@@ -332,7 +332,7 @@ class RegionForecastValue(BaseModel):
     region_name: str
     capacity_kW: float
     power_kW: float
-    plevels_kW: dict[str, float] = Field(default_factory=dict)
+    plevels_kW: dict[str, float] | None = None
 
 
 class ForecastSnapshot(BaseModel):

--- a/src/quartz_api/internal/service/v1/routes/forecasts.py
+++ b/src/quartz_api/internal/service/v1/routes/forecasts.py
@@ -218,6 +218,7 @@ async def get_forecast_last_updated_timestamp(
     status_code=status.HTTP_200_OK,
     summary="Get Forecasts at Timestamp",
     response_model=ForecastSnapshot,
+    response_model_exclude_none=True,
 )
 @cache(key_builder=key_builder, expire=120)
 async def get_forecasts_at_time(
@@ -295,7 +296,7 @@ async def get_forecasts_at_time(
                 region_name=region_names.get(v.location_uuid, ""),
                 capacity_kW=v.capacity_kilowatts,
                 power_kW=v.power_kilowatts,
-                plevels_kW=v.plevels_kilowatts,
+                plevels_kW=v.plevels_kilowatts or None,
             )
             for v in snapshot
         ],

--- a/src/quartz_api/internal/service/v1/routes/forecasts.py
+++ b/src/quartz_api/internal/service/v1/routes/forecasts.py
@@ -147,7 +147,7 @@ async def get_forecast(
         horizon_minutes=horizon_minutes,
         values=[
             ForecastValue(
-                time=v.valid_timestamp,
+                time_utc=v.valid_timestamp,
                 power_kW=v.power_kilowatts,
                 plevels_kW=v.plevels_kilowatts,
             )
@@ -285,7 +285,7 @@ async def get_forecasts_at_time(
     region_names = {to_uuid(r.uuid): location_display_name(r, country) for r in regions}
     first = snapshot[0] if snapshot else None
     return ForecastSnapshot(
-        time=snapshot_time,
+        time_utc=snapshot_time,
         model_name=internal_to_api_name(first.forecaster_name if first else None, rt),
         model_version=first.forecaster_version if first else None,
         last_updated_utc=first.created_timestamp if first else None,
@@ -421,10 +421,10 @@ async def get_forecasts_period(
         if raw is None:
             continue
         all_values = [ForecastValue.model_validate(v) for v in json.loads(raw)]
-        windowed = [v for v in all_values if win_start <= v.time <= win_end]
+        windowed = [v for v in all_values if win_start <= v.time_utc <= win_end]
         all_region_data.append((r, windowed))
 
-    times = [v.time for v in all_region_data[0][1]] if all_region_data else []
+    times = [v.time_utc for v in all_region_data[0][1]] if all_region_data else []
     region_series: list[RegionForecast] = []
     for r, windowed in all_region_data:
         plevel_keys = {k for v in windowed for k in v.plevels_kW}
@@ -440,7 +440,7 @@ async def get_forecasts_period(
         )
 
     metadata = json.loads(raw_meta)
-    return RegionForecastMatrix(**metadata, times=times, regions=region_series)
+    return RegionForecastMatrix(**metadata, times_utc=times, regions=region_series)
 
 
 @router.post(

--- a/src/quartz_api/internal/service/v1/routes/generation.py
+++ b/src/quartz_api/internal/service/v1/routes/generation.py
@@ -129,7 +129,7 @@ async def get_generation(
         capacity_kW=first.capacity_kilowatts if first else 0.0,
         observer_name=observer,
         values=[
-            GenerationValue(time=v.valid_timestamp, power_kW=v.power_kilowatts)
+            GenerationValue(time_utc=v.valid_timestamp, power_kW=v.power_kilowatts)
             for v in agvs
         ],
     )
@@ -235,7 +235,7 @@ async def get_generation_at_timestamp(
 
     region_names = {to_uuid(r.uuid): location_display_name(r, country) for r in regions}
     return GenerationSnapshot(
-        time=snapshot_time,
+        time_utc=snapshot_time,
         observer_name=observer,
         values=[
             RegionGenerationValue(
@@ -378,10 +378,10 @@ async def get_generation_period(
         if raw is None:
             continue
         all_values = [GenerationValue.model_validate(v) for v in json.loads(raw)]
-        windowed = [v for v in all_values if win_start <= v.time <= win_end]
+        windowed = [v for v in all_values if win_start <= v.time_utc <= win_end]
         all_region_data.append((r, windowed))
 
-    times = [v.time for v in all_region_data[0][1]] if all_region_data else []
+    times = [v.time_utc for v in all_region_data[0][1]] if all_region_data else []
     region_series: list[RegionGeneration] = []
     for r, windowed in all_region_data:
         region_series.append(
@@ -393,7 +393,7 @@ async def get_generation_period(
         )
 
     metadata = json.loads(raw_meta)
-    return RegionGenerationMatrix(**metadata, times=times, regions=region_series)
+    return RegionGenerationMatrix(**metadata, times_utc=times, regions=region_series)
 
 
 @router.post(

--- a/src/quartz_api/internal/service/v1/test_router.py
+++ b/src/quartz_api/internal/service/v1/test_router.py
@@ -640,7 +640,7 @@ async def test_get_forecasts_snapshot(client: AsyncClient) -> None:
     resp = await client.get("/v1/GB/solar/forecasts/snapshot?region_type=gsp")
     assert resp.status_code == 200
     body = resp.json()
-    assert "time" in body
+    assert "time_utc" in body
     assert "values" in body
 
 
@@ -655,7 +655,7 @@ async def test_get_generation_snapshot(client: AsyncClient) -> None:
     resp = await client.get("/v1/GB/solar/generation/snapshot?region_type=gsp")
     assert resp.status_code == 200
     body = resp.json()
-    assert "time" in body
+    assert "time_utc" in body
     assert "observer_name" in body
     assert "values" in body
 
@@ -674,7 +674,7 @@ async def test_get_forecasts_snapshot_national_fallback(client: AsyncClient) -> 
     resp = await client.get("/v1/GB/solar/forecasts/snapshot?region_type=national")
     assert resp.status_code == 200
     body = resp.json()
-    assert "time" in body
+    assert "time_utc" in body
     assert "values" in body
 
 
@@ -810,8 +810,8 @@ async def test_get_forecasts_period_window_includes_cached_values(
     await _set_forecast_meta()
     await _set_fixed_region_values(
         [
-            {"time": t_early.isoformat(), "power_kW": 100.0, "plevels_kW": {}},
-            {"time": t_late.isoformat(), "power_kW": 200.0, "plevels_kW": {}},
+            {"time_utc": t_early.isoformat(), "power_kW": 100.0, "plevels_kW": {}},
+            {"time_utc": t_late.isoformat(), "power_kW": 200.0, "plevels_kW": {}},
         ],
     )
 
@@ -828,7 +828,7 @@ async def test_get_forecasts_period_window_includes_cached_values(
     body = resp.json()
     regions = body["regions"]
     assert len(regions) == 1
-    assert len(body["times"]) == 1
+    assert len(body["times_utc"]) == 1
     assert regions[0]["power_kW"] == [100.0]
 
 
@@ -843,7 +843,7 @@ async def test_get_forecasts_period_window_excludes_out_of_range_values(
     await _set_forecast_meta()
     await _set_fixed_region_values(
         [
-            {"time": t_past.isoformat(), "power_kW": 50.0, "plevels_kW": {}},
+            {"time_utc": t_past.isoformat(), "power_kW": 50.0, "plevels_kW": {}},
         ],
     )
 
@@ -858,7 +858,7 @@ async def test_get_forecasts_period_window_excludes_out_of_range_values(
     )
     assert resp.status_code == 200
     body = resp.json()
-    assert body["times"] == []
+    assert body["times_utc"] == []
     assert body["regions"][0]["power_kW"] == []
 
 
@@ -1195,7 +1195,7 @@ async def test_get_forecasts_snapshot_explicit_timestamp(client: AsyncClient) ->
         f"/v1/GB/solar/forecasts/snapshot?region_type=gsp&time_utc={ts}",
     )
     assert resp.status_code == 200
-    assert resp.json()["time"].startswith("2026-04-17T12:00:00")
+    assert resp.json()["time_utc"].startswith("2026-04-17T12:00:00")
 
 
 @pytest.mark.anyio
@@ -1265,7 +1265,7 @@ async def test_get_generation_snapshot_explicit_timestamp(client: AsyncClient) -
         f"/v1/GB/solar/generation/snapshot?region_type=gsp&time_utc={ts}",
     )
     assert resp.status_code == 200
-    assert resp.json()["time"].startswith("2026-04-17T10:30:00")
+    assert resp.json()["time_utc"].startswith("2026-04-17T10:30:00")
 
 
 @pytest.mark.anyio
@@ -1367,8 +1367,8 @@ async def test_get_generation_period_start_and_end_utc(
     await _set_generation_meta()
     await _set_fixed_generation_values(
         [
-            {"time": t_early.isoformat(), "power_kW": 111.0},
-            {"time": t_late.isoformat(), "power_kW": 222.0},
+            {"time_utc": t_early.isoformat(), "power_kW": 111.0},
+            {"time_utc": t_late.isoformat(), "power_kW": 222.0},
         ],
     )
 
@@ -1384,7 +1384,7 @@ async def test_get_generation_period_start_and_end_utc(
     body = resp.json()
     regions = body["regions"]
     assert len(regions) == 1
-    assert len(body["times"]) == 1
+    assert len(body["times_utc"]) == 1
     assert regions[0]["power_kW"] == [111.0]
 
 
@@ -1686,7 +1686,7 @@ async def test_nl_forecast_snapshot(nl_client: AsyncClient) -> None:
     """NL forecast snapshot for national region type returns 200."""
     resp = await nl_client.get("/v1/NL/solar/forecasts/snapshot?region_type=national")
     assert resp.status_code == 200
-    assert "time" in resp.json()
+    assert "time_utc" in resp.json()
     assert "values" in resp.json()
 
 
@@ -1772,7 +1772,7 @@ async def test_nl_forecast_period_display_name_filter(
         json.dumps(
             [
                 {
-                    "time": "2026-01-01T12:00:00+00:00",
+                    "time_utc": "2026-01-01T12:00:00+00:00",
                     "power_kW": 100.0,
                     "plevels_kW": {},
                 },


### PR DESCRIPTION
# Pull Request

## Description

General fixes to early Beta:

- **DP observer name leaking in `/generation/period` response** — `_meta` stored the internal DP name (e.g. `nednl`) instead of the user-facing slug (e.g. `ned_nl`)
- **Rename `time` → `time_utc` across all v1 response fields** — applies to `ForecastValue`, `GenerationValue`, both snapshot wrappers, and the matrix `times` array; cache serialisation keys updated to match
- **Omit `plevels_kW` from forecast snapshot when DP returns none** — field is now `null`-excluded rather than returning `{}`

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [x] Locally (manual API testing + unit tests)
- [x] CI tests

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added/amended tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
