### PR TITLE
Update resp fields and implement put_actual_generation & put_location methods

### DIFF
--- a/src/quartz_api/internal/backends/dataplatform/client.py
+++ b/src/quartz_api/internal/backends/dataplatform/client.py
@@ -517,9 +517,23 @@ class StorageClient(models.StorageInterface):
             location_uuid=location.uuid,
         )
         if not existing:
-            raise HTTPException(
-                status_code=404,
-                detail=f"No location found for UUID '{location.uuid}'",
+            create_req = messages_pb2.CreateLocationRequest(
+                location_name=location.name,
+                energy_source=energy_type_map[energy_type],
+                geometry_wkt=f"POINT ({location.longitude} {location.latitude})",
+                effective_capacity_watts=int(location.capacity_kilowatts * 1000),
+                location_type=location_type_map[location_type],
+                metadata=dict_to_struct(location.metadata),
+            )
+            created = await self.dpc.CreateLocation(create_req)
+            return models.Location(
+                uuid=UUID(created.location_uuid),
+                name=created.location_name,
+                latitude=location.latitude,
+                longitude=location.longitude,
+                capacity_kilowatts=created.effective_capacity_watts / 1000.0,
+                location_type=location_type,
+                metadata=location.metadata,
             )
         current = existing[0]
 

--- a/src/quartz_api/internal/backends/dataplatform/client.py
+++ b/src/quartz_api/internal/backends/dataplatform/client.py
@@ -55,6 +55,13 @@ def struct_to_dict(pb_struct: Struct) -> dict[str, str | float | bool]:
     return out
 
 
+def dict_to_struct(d: dict[str, str | int | float | bool]) -> Struct:
+    """Convert a flat python dictionary into a protobuf Struct."""
+    s = Struct()
+    s.update(d)
+    return s
+
+
 class StorageClient(models.StorageInterface):
     """Defines a data platform conneciton that conforms to the StorageInterface."""
 
@@ -289,13 +296,37 @@ class StorageClient(models.StorageInterface):
     async def put_actual_generation(
         self,
         generation_values: list[models.ActualGenerationValue],
+        location_uuid: UUID | str,
         energy_type: models.EnergyType,
         location_type: models.LocationType,
         authdata: dict[str, str],
     ) -> None:
-        raise NotImplementedError(
-            "Data platform backend does not yet support writing generation",
+        if not generation_values:
+            return
+
+        if authdata != {}:
+            _ = await self._check_user_access(
+                location_uuid=location_uuid,
+                energy_source=energy_type_map[energy_type],
+                location_type=location_type_map[location_type],
+                oauth_id=get_oauth_id_from_sub(authdata["sub"]),
+            )
+
+        observer_name = generation_values[0].observer_name
+
+        req = messages_pb2.CreateObservationsRequest(
+            location_uuid=str(location_uuid),
+            energy_source=energy_type_map[energy_type],
+            observer_name=observer_name,
+            values=[
+                messages_pb2.CreateObservationsRequest.Value(
+                    timestamp_utc=gv.valid_timestamp,
+                    value_watts=max(0, int(gv.power_kilowatts * 1000)),
+                )
+                for gv in generation_values
+            ],
         )
+        await self.dpc.CreateObservations(req)
 
     @override
     async def get_predicted_generation_snapshot(
@@ -479,8 +510,43 @@ class StorageClient(models.StorageInterface):
         energy_type: models.EnergyType,
         authdata: dict[str, str],
     ) -> models.Location:
-        raise NotImplementedError(
-            "Data platform backend doesn't yet support location writing.",
+        existing = await self.get_locations(
+            energy_type=energy_type,
+            location_type=location_type,
+            authdata=authdata,
+            location_uuid=location.uuid,
+        )
+        if not existing:
+            raise HTTPException(
+                status_code=404,
+                detail=f"No location found for UUID '{location.uuid}'",
+            )
+        current = existing[0]
+
+        """new_metadata replaces existing metadata entirely, so merge new values over the
+        current.
+        """
+        merged_metadata = {**current.metadata, **location.metadata}
+
+        req = messages_pb2.UpdateLocationRequest(
+            location_uuid=str(location.uuid),
+            energy_source=energy_type_map[energy_type],
+            new_effective_capacity_watts=int(location.capacity_kilowatts * 1000),
+            new_metadata=dict_to_struct(merged_metadata),
+        )
+        if location.name:
+            req.new_location_name = location.name
+
+        resp = await self.dpc.UpdateLocation(req)
+
+        return models.Location(
+            uuid=UUID(resp.location_uuid),
+            name=resp.location_name,
+            latitude=current.latitude,
+            longitude=current.longitude,
+            capacity_kilowatts=resp.effective_capacity_watts / 1000.0,
+            location_type=location_type,
+            metadata=merged_metadata,
         )
 
     @override

--- a/src/quartz_api/internal/backends/dataplatform/test_client.py
+++ b/src/quartz_api/internal/backends/dataplatform/test_client.py
@@ -521,3 +521,103 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(resp[0].power_kilowatts, 500.0)
 
+    @patch("ocf.dp.dp_data.service_pb2_grpc.DataPlatformDataServiceStub")
+    async def test_put_actual_generation(
+        self,
+        client_mock: service_pb2_grpc.DataPlatformDataServiceStub,
+    ) -> None:
+        site_uuid = uuid.uuid4()
+        gen_values = [
+            models.ActualGenerationValue(
+                power_kilowatts=1.5,
+                valid_timestamp=TEST_TIMESTAMP_UTC,
+                location_uuid=site_uuid,
+                capacity_kilowatts=0,
+                observer_name="ruvnl",
+            ),
+        ]
+        client = StorageClient.from_dp(client_mock)
+
+        # When the user has access, observations are written as absolute watts.
+        client_mock.ListLocations = AsyncMock(side_effect=mock_list_locations)
+        client_mock.CreateObservations = AsyncMock(
+            return_value=messages_pb2.CreateObservationsResponse(),
+        )
+        await client.put_actual_generation(
+            generation_values=gen_values,
+            location_uuid=site_uuid,
+            energy_type=models.EnergyType.SOLAR,
+            location_type=models.LocationType.SITE,
+            authdata={"sub": "access_user"},
+        )
+        client_mock.CreateObservations.assert_called_once()
+        sent = client_mock.CreateObservations.call_args.args[0]
+        self.assertEqual(sent.observer_name, "ruvnl")
+        self.assertEqual(sent.values[0].value_watts, 1500)
+
+        # When the user has no access, the write is rejected.
+        client_mock.ListLocations = AsyncMock(side_effect=mock_list_locations)
+        with self.assertRaises(HTTPException):
+            await client.put_actual_generation(
+                generation_values=gen_values,
+                location_uuid=site_uuid,
+                energy_type=models.EnergyType.SOLAR,
+                location_type=models.LocationType.SITE,
+                authdata={"sub": "no_access_user"},
+            )
+
+    @patch("ocf.dp.dp_data.service_pb2_grpc.DataPlatformDataServiceStub")
+    async def test_put_location(
+        self,
+        client_mock: service_pb2_grpc.DataPlatformDataServiceStub,
+    ) -> None:
+        def mock_update_location(
+            req: messages_pb2.UpdateLocationRequest,
+            metadata: object | None = None,  # noqa: ARG001
+        ) -> messages_pb2.UpdateLocationResponse:
+            return messages_pb2.UpdateLocationResponse(
+                location_uuid=req.location_uuid,
+                location_name=req.new_location_name or "mock_location",
+                effective_capacity_watts=req.new_effective_capacity_watts,
+            )
+
+        site_uuid = uuid.uuid4()
+        loc = models.Location(
+            uuid=site_uuid,
+            name="updated_site_name",
+            latitude=0.0,
+            longitude=0.0,
+            capacity_kilowatts=5.0,
+            metadata={"tilt": 35.0},
+        )
+        client = StorageClient.from_dp(client_mock)
+
+        client_mock.ListLocations = AsyncMock(side_effect=mock_list_locations)
+        client_mock.UpdateLocation = AsyncMock(side_effect=mock_update_location)
+
+        resp = await client.put_location(
+            location=loc,
+            location_type=models.LocationType.SITE,
+            energy_type=models.EnergyType.SOLAR,
+            authdata={"sub": "access_user"},
+        )
+        # Capacity round-trips kW -> watts -> kW, and lat/lng come from the fetched location.
+        self.assertEqual(resp.capacity_kilowatts, 5.0)
+        self.assertEqual(resp.latitude, 51.5)
+
+        sent = client_mock.UpdateLocation.call_args.args[0]
+        self.assertEqual(sent.new_effective_capacity_watts, 5000)
+        # Metadata is merged: existing orientation preserved, tilt overridden by the new value.
+        self.assertEqual(dict(sent.new_metadata)["orientation"], 180.0)
+        self.assertEqual(dict(sent.new_metadata)["tilt"], 35.0)
+
+        # Updating a location the user cannot see raises a 404.
+        client_mock.ListLocations = AsyncMock(side_effect=mock_list_locations)
+        with self.assertRaises(HTTPException):
+            await client.put_location(
+                location=loc,
+                location_type=models.LocationType.SITE,
+                energy_type=models.EnergyType.SOLAR,
+                authdata={"sub": "no_access_user"},
+            )
+

--- a/src/quartz_api/internal/backends/dataplatform/test_client.py
+++ b/src/quartz_api/internal/backends/dataplatform/test_client.py
@@ -581,6 +581,16 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
                 effective_capacity_watts=req.new_effective_capacity_watts,
             )
 
+        def mock_create_location(
+            req: messages_pb2.CreateLocationRequest,
+            metadata: object | None = None,  # noqa: ARG001
+        ) -> messages_pb2.CreateLocationResponse:
+            return messages_pb2.CreateLocationResponse(
+                location_uuid=str(uuid.uuid4()),
+                location_name=req.location_name,
+                effective_capacity_watts=req.effective_capacity_watts,
+            )
+
         site_uuid = uuid.uuid4()
         loc = models.Location(
             uuid=site_uuid,
@@ -611,13 +621,21 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(dict(sent.new_metadata)["orientation"], 180.0)
         self.assertEqual(dict(sent.new_metadata)["tilt"], 35.0)
 
-        # Updating a location the user cannot see raises a 404.
+        # When no matching location is visible to the caller, a new one is created instead.
         client_mock.ListLocations = AsyncMock(side_effect=mock_list_locations)
-        with self.assertRaises(HTTPException):
-            await client.put_location(
-                location=loc,
-                location_type=models.LocationType.SITE,
-                energy_type=models.EnergyType.SOLAR,
-                authdata={"sub": "no_access_user"},
-            )
+        client_mock.CreateLocation = AsyncMock(side_effect=mock_create_location)
+        created = await client.put_location(
+            location=loc,
+            location_type=models.LocationType.SITE,
+            energy_type=models.EnergyType.SOLAR,
+            authdata={"sub": "no_access_user"},
+        )
+        self.assertNotEqual(created.uuid, site_uuid)
+        self.assertEqual(created.capacity_kilowatts, 5.0)
+        self.assertEqual(created.latitude, 0.0)
+
+        sent_create = client_mock.CreateLocation.call_args.args[0]
+        self.assertEqual(sent_create.effective_capacity_watts, 5000)
+        self.assertEqual(sent_create.geometry_wkt, "POINT (0.0 0.0)")
+        self.assertEqual(dict(sent_create.metadata)["tilt"], 35.0)
 

--- a/src/quartz_api/internal/service/regions/_resample.py
+++ b/src/quartz_api/internal/service/regions/_resample.py
@@ -48,18 +48,18 @@ def smooth_forecast(values: list[PredictedPower]) -> list[PredictedPower]:
     # convert to dataframe
     df = pd.DataFrame(
         {
-            "time": [value.time for value in values],
-            "power_kW": [value.power_kW for value in values],
+            "Time": [value.Time for value in values],
+            "PowerKW": [value.PowerKW for value in values],
         },
     )
 
     # smooth and make sure it is symmetrical
-    df = df.set_index("time")
+    df = df.set_index("Time")
     # try to do this in one step, but couldnt, center=True and closed='both' didnt work
     df = (df.rolling(4, min_periods=1).mean() + df[::-1].rolling(4, min_periods=1).mean()) / 2.0
 
     # convert to ints
-    df["power_kW"] = df["power_kW"].astype(int)
+    df["PowerKW"] = df["PowerKW"].astype(int)
     df["created_time"] = [value.created_time for value in values]
     df["initialization_timestamp_utc"] = [value.initialization_timestamp_utc for value in values]
     df["forecaster_name"] = [value.forecaster_name for value in values]
@@ -69,8 +69,8 @@ def smooth_forecast(values: list[PredictedPower]) -> list[PredictedPower]:
     # convert back to list of PredictedPower
     return [
         PredictedPower(
-            time=index,
-            power_kW=row.power_kW,
+            Time=index,
+            PowerKW=row.PowerKW,
             created_time=row.created_time,
             initialization_timestamp_utc=row.initialization_timestamp_utc,
             forecaster_name=row.forecaster_name,

--- a/src/quartz_api/internal/service/regions/endpoint_types.py
+++ b/src/quartz_api/internal/service/regions/endpoint_types.py
@@ -20,8 +20,8 @@ class ActualPower(BaseModel):
 class PredictedPower(BaseModel):
     """Defines the data structure for a predicted power value returned by the API."""
 
-    power_kW: float
-    time: dt.datetime
+    PowerKW: float
+    Time: dt.datetime
     created_time: dt.datetime | None = Field(None, exclude=True)
     initialization_timestamp_utc: dt.datetime | None = Field(
         None,

--- a/src/quartz_api/internal/service/regions/router.py
+++ b/src/quartz_api/internal/service/regions/router.py
@@ -179,8 +179,8 @@ async def get_forecast_timeseries_route(
     values: list[PredictedPower] = [
         PredictedPower(
             location_uuid=str(pgv.location_uuid),
-            power_kW=pgv.power_kilowatts,
-            time=pgv.valid_timestamp.astimezone(tz=tz),
+            PowerKW=pgv.power_kilowatts,
+            Time=pgv.valid_timestamp.astimezone(tz=tz),
             created_time=pgv.created_timestamp.astimezone(tz=tz),
             initialization_timestamp_utc=pgv.init_timestamp.astimezone(tz=tz),
             forecaster_version=pgv.forecaster_version,

--- a/src/quartz_api/internal/service/sites/endpoint_types.py
+++ b/src/quartz_api/internal/service/sites/endpoint_types.py
@@ -59,8 +59,8 @@ class Site(SiteProperties):
 class PredictedPower(BaseModel):
     """Defines the data structure for a predicted power value returned by the API."""
 
-    power_kW: float
-    time: AwareDatetime
+    PowerKW: float
+    Time: AwareDatetime
     created_time: AwareDatetime | None = Field(None, exclude=True)
     initialization_timestamp_utc: AwareDatetime | None = Field(
         None,

--- a/src/quartz_api/internal/service/sites/router.py
+++ b/src/quartz_api/internal/service/sites/router.py
@@ -120,8 +120,8 @@ async def get_forecast(
     )
     out: list[PredictedPower] = [
         PredictedPower(
-            power_kW=v.power_kilowatts,
-            time=v.valid_timestamp.astimezone(tz=tz),
+            PowerKW=v.power_kilowatts,
+            Time=v.valid_timestamp.astimezone(tz=tz),
             created_time=v.created_timestamp.astimezone(tz=tz),
             initialization_timestamp_utc=v.init_timestamp.astimezone(tz=tz),
             forecaster_name=v.forecaster_name,


### PR DESCRIPTION
# Pull Request

## Description

- Updated model returns (`power_kw` to `PowerKW` and `time` to `Time`)
- Implemented `put_actual_generation` method
- Implemented `put_location` method
- Added test

Fixes
- https://github.com/openclimatefix/client-private/issues/475
- https://github.com/openclimatefix/client-private/issues/476
- https://github.com/openclimatefix/client-private/issues/477

## How Has This Been Tested?

- [x] Integration test
- [x] CI

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
