### PR TITLE
fix: pass auth_instance to sentry middleware

### DIFF
--- a/src/quartz_api/cmd/main.py
+++ b/src/quartz_api/cmd/main.py
@@ -464,7 +464,7 @@ def _create_server(conf: ConfigTree) -> FastAPI:
     )
     if conf.get_string("backend.source") != "dataplatform":
         server.add_middleware(audit.RequestLoggerMiddleware)
-    server.add_middleware(sentry.SentryUserMiddleware, auth_instance=None)
+    server.add_middleware(sentry.SentryUserMiddleware, auth_instance=auth.auth_instance)
     if conf.get_string("apitally.client_id") != "":
         server.add_middleware(
             ApitallyMiddleware,

--- a/src/quartz_api/internal/middleware/sentry.py
+++ b/src/quartz_api/internal/middleware/sentry.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI, Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from quartz_api.internal.middleware import auth
+from quartz_api.internal.middleware.auth import get_org_id_from_authdata
 
 
 class SentryUserMiddleware(BaseHTTPMiddleware):
@@ -41,6 +42,9 @@ class SentryUserMiddleware(BaseHTTPMiddleware):
                             "email": payload.get(auth.EMAIL_KEY),
                         },
                     )
+                    org_id = get_org_id_from_authdata(payload)
+                    if org_id:
+                        sentry_sdk.set_tag("hubspot_company_id", org_id)
             except Exception:
                 # silently fail to not break requests
                 logging.debug("Could not extract user for Sentry")


### PR DESCRIPTION
# Pull Request

## Description

Sentry was only showing client IP addresses and was not logging user email information because the auth instance was not being passed through.


Fixes #329 


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
