### PR TITLE
feat: upgrade dp-sdk to v0.32.0, migrate to organization-based access…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
 classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
     "cryptography >= 41.0.0",
-    "dp-sdk >= 0.29.0,<1.0.0",
+    "dp-sdk >= 0.32.0,<1.0.0",
     "fastapi>=0.105.0",
     "pvsite-datamodel == 1.2.3",
     "pyjwt >= 2.8.0",
@@ -65,7 +65,7 @@ dev = [
 ]
 
 [tool.uv.sources]
-dp-sdk = { url = "https://github.com/openclimatefix/data-platform/releases/download/v0.29.0/dp_sdk-0.29.0-py3-none-any.whl" }
+dp-sdk = { url = "https://github.com/openclimatefix/data-platform/releases/download/v0.32.0/dp_sdk-0.32.0-py3-none-any.whl" }
 
 [project.urls]
 repository = "https://github.com/openclimatefix/quartz-api"

--- a/src/quartz_api/internal/backends/dataplatform/client.py
+++ b/src/quartz_api/internal/backends/dataplatform/client.py
@@ -13,9 +13,22 @@ from timezonefinder import timezone_at
 from typing_extensions import override
 
 from quartz_api.internal import models
-from quartz_api.internal.middleware.auth import get_oauth_id_from_sub
 
 log = logging.getLogger("dataplatform.client")
+
+HUBSPOT_COMPANY_ID_KEY = "hubspot_company_id"
+
+
+def get_org_id_from_authdata(authdata: dict[str, str]) -> str | None:
+    """Extract the HubSpot company ID from JWT app_metadata claims.
+
+    The JWT contains app_metadata with hubspot_company_id which maps
+    to organisation_id_filter in the Data Platform.
+    """
+    app_metadata = authdata.get("app_metadata", {})
+    if isinstance(app_metadata, dict):
+        return app_metadata.get(HUBSPOT_COMPANY_ID_KEY)
+    return None
 
 energy_type_map: dict[models.EnergyType, common_pb2.EnergySource] = {
     models.EnergyType.SOLAR: common_pb2.EnergySource.ENERGY_SOURCE_SOLAR,
@@ -99,14 +112,12 @@ class StorageClient(models.StorageInterface):
                 minutes=forecast_horizon_minutes,
             )
 
-        oauth_id: str | None = (
-            get_oauth_id_from_sub(authdata["sub"]) if authdata != {} else None
-        )
+        organisation_id: str | None = get_org_id_from_authdata(authdata) if authdata != {} else None
         req = messages_pb2.ListLocationsRequest(
             location_uuids_filter=[str(location_uuid)],
             energy_source_filter=energy_type_map[energy_type],
             location_type_filter=location_type_map[location_type],
-            user_oauth_id_filter=oauth_id,
+            organisation_id_filter=organisation_id,
         )
         resp = await self.dpc.ListLocations(req)
         if len(resp.locations) == 0:
@@ -122,7 +133,6 @@ class StorageClient(models.StorageInterface):
             req = messages_pb2.ListLocationsRequest(
                 enclosed_location_uuid_filter=str(location_uuid),
                 location_type_filter=common_pb2.LocationType.LOCATION_TYPE_GSP,
-                user_oauth_id_filter=oauth_id,
             )
             gsps = await self.dpc.ListLocations(req)
             if len(gsps.locations) == 0:
@@ -282,7 +292,7 @@ class StorageClient(models.StorageInterface):
                 location_uuid=location_uuid,
                 energy_source=energy_type_map[energy_type],
                 location_type=location_type_map[location_type],
-                oauth_id=get_oauth_id_from_sub(authdata["sub"]),
+                org_id=get_org_id_from_authdata(authdata),
             )
 
         req = messages_pb2.GetObservationsAsTimeseriesRequest(
@@ -331,7 +341,7 @@ class StorageClient(models.StorageInterface):
                 location_uuid=location_uuid,
                 energy_source=energy_type_map[energy_type],
                 location_type=location_type_map[location_type],
-                oauth_id=get_oauth_id_from_sub(authdata["sub"]),
+                org_id=get_org_id_from_authdata(authdata),
             )
 
         observer_name = generation_values[0].observer_name
@@ -452,49 +462,26 @@ class StorageClient(models.StorageInterface):
     @override
     async def get_locations(
         self,
-        energy_type: models.EnergyType,
+        energy_type: models.EnergyType | None,
         location_type: models.LocationType | None,
         authdata: dict[str, str],
         location_uuid: UUID | None = None,
         enclosing_location_uuid: UUID | None = None,
         location_names: list[str] | None = None,
     ) -> list[models.Location]:
-        # For the moment, recreate the auth behaviour of the old routes in here.
-        # This should be delegated to the scoping on the API endpoints themselves later.
-        match energy_type, location_type:
-            case models.EnergyType.WIND, models.LocationType.REGION:
-                # get_wind_regions had no auth
-                oauth_id: str | None = None
-            case (
-                models.EnergyType.SOLAR,
-                models.LocationType.NATION | models.LocationType.GSP | models.LocationType.REGION,
-            ):
-                # get_solar_regions had no auth
-                oauth_id = None
-            case _, models.LocationType.SUBSTATION:
-                # get substations had optional auth (?) (temporary while we onboard?)
-                oauth_id = (
-                    get_oauth_id_from_sub(authdata["sub"]) if authdata != {} else None
-                )
-            case _, models.LocationType.SITE:
-                # get_sites had auth
-                oauth_id = get_oauth_id_from_sub(authdata["sub"])
-            case _, None:
-                # No location type filter — used by v1 API for listing all region types
-                oauth_id = (
-                    get_oauth_id_from_sub(authdata["sub"]) if authdata != {} else None
-                )
-            case _:
-                oauth_id = (
-                    get_oauth_id_from_sub(authdata["sub"]) if authdata != {} else None
-                )
+        # Filter by org ID (HubSpot company ID) from the JWT app_metadata.
+        organisation_id: str | None = (
+            get_org_id_from_authdata(authdata) if authdata != {} else None
+        )
 
         req = messages_pb2.ListLocationsRequest(
-            energy_source_filter=energy_type_map[energy_type],
+            energy_source_filter=(
+                energy_type_map[energy_type] if energy_type is not None else None
+            ),
             location_type_filter=(
                 location_type_map[location_type] if location_type is not None else None
             ),
-            user_oauth_id_filter=oauth_id,
+            organisation_id_filter=organisation_id,
             location_uuids_filter=(
                 [str(location_uuid)] if location_uuid is not None else []
             ),
@@ -507,6 +494,11 @@ class StorageClient(models.StorageInterface):
         )
         resp = await self.dpc.ListLocations(req)
 
+        # Reverse map from proto EnergySource -> internal EnergyType
+        dp_to_internal_energy_type: dict[common_pb2.EnergySource, models.EnergyType] = {
+            v: k for k, v in energy_type_map.items()
+        }
+
         def _map_resp(resp: messages_pb2.ListLocationsResponse) -> list[models.Location]:
             out: list[models.Location] = [
                 models.Location(
@@ -516,6 +508,7 @@ class StorageClient(models.StorageInterface):
                     latitude=loc.latlng.latitude,
                     longitude=loc.latlng.longitude,
                     location_type=dp_to_internal_location_type.get(loc.location_type),
+                    energy_type=dp_to_internal_energy_type.get(loc.energy_source),
                     metadata=struct_to_dict(loc.metadata) if loc.metadata is not None else {},
                 )
                 for loc in resp.locations
@@ -598,20 +591,20 @@ class StorageClient(models.StorageInterface):
         location_uuid: UUID,
         energy_source: common_pb2.EnergySource,
         location_type: common_pb2.LocationType,
-        oauth_id: str,
+        org_id: str | None,
     ) -> models.Location:
-        """Check if a user has access to a given location."""
+        """Check if an organisation has access to a given location."""
         req = messages_pb2.ListLocationsRequest(
             location_uuids_filter=[str(location_uuid)],
             energy_source_filter=energy_source,
             location_type_filter=location_type,
-            user_oauth_id_filter=oauth_id,
+            organisation_id_filter=org_id,
         )
         resp = await self.dpc.ListLocations(req)
         if len(resp.locations) == 0:
             raise HTTPException(
                 status_code=404,
-                detail=f"No location found for UUID {location_uuid} and OAuth ID {oauth_id}",
+                detail=f"No location found for UUID {location_uuid} and org ID {org_id}",
             )
         loc = resp.locations[0]
 

--- a/src/quartz_api/internal/backends/dataplatform/client.py
+++ b/src/quartz_api/internal/backends/dataplatform/client.py
@@ -27,7 +27,7 @@ def get_org_id_from_authdata(authdata: dict[str, str]) -> str | None:
     """
     app_metadata = authdata.get("app_metadata", {})
     if isinstance(app_metadata, dict):
-        return app_metadata.get(HUBSPOT_COMPANY_ID_KEY)
+        return app_metadata.get("hubspot_company_id")
     return None
 
 energy_type_map: dict[models.EnergyType, common_pb2.EnergySource] = {

--- a/src/quartz_api/internal/backends/dataplatform/client.py
+++ b/src/quartz_api/internal/backends/dataplatform/client.py
@@ -287,7 +287,7 @@ class StorageClient(models.StorageInterface):
         if observer_name is None:
             raise ValueError("Observer must be specified for data platform backend.")
 
-        if authdata != {}:
+        if authdata != {} and location_type == models.LocationType.SITE:
             _ = await self._check_user_access(
                 location_uuid=location_uuid,
                 energy_source=energy_type_map[energy_type],
@@ -336,7 +336,7 @@ class StorageClient(models.StorageInterface):
         if not generation_values:
             return
 
-        if authdata != {}:
+        if authdata != {} and location_type == models.LocationType.SITE:
             _ = await self._check_user_access(
                 location_uuid=location_uuid,
                 energy_source=energy_type_map[energy_type],
@@ -469,10 +469,35 @@ class StorageClient(models.StorageInterface):
         enclosing_location_uuid: UUID | None = None,
         location_names: list[str] | None = None,
     ) -> list[models.Location]:
-        # Filter by org ID (HubSpot company ID) from the JWT app_metadata.
-        organisation_id: str | None = (
-            get_org_id_from_authdata(authdata) if authdata != {} else None
-        )
+        # For the moment, recreate the auth behaviour of the old routes in here.
+        # This should be delegated to the scoping on the API endpoints themselves later.
+        match energy_type, location_type:
+            case models.EnergyType.WIND, models.LocationType.REGION:
+                # get_wind_regions had no auth
+                organisation_id: str | None = None
+            case (
+                models.EnergyType.SOLAR,
+                models.LocationType.NATION | models.LocationType.GSP | models.LocationType.REGION,
+            ):
+                # get_solar_regions had no auth
+                organisation_id = None
+            case _, models.LocationType.SUBSTATION:
+                # get substations had optional auth (?) (temporary while we onboard?)
+                organisation_id = None
+            case _, models.LocationType.SITE:
+                # get_sites had auth (HubSpot company ID)
+                organisation_id = (
+                    get_org_id_from_authdata(authdata) if authdata != {} else None
+                )
+            case _, None:
+                # No location type filter — used by v1 API for listing all region types
+                organisation_id = (
+                    get_org_id_from_authdata(authdata) if authdata != {} else None
+                )
+            case _:
+                organisation_id = (
+                    get_org_id_from_authdata(authdata) if authdata != {} else None
+                )
 
         req = messages_pb2.ListLocationsRequest(
             energy_source_filter=(

--- a/src/quartz_api/internal/backends/dataplatform/client.py
+++ b/src/quartz_api/internal/backends/dataplatform/client.py
@@ -1,6 +1,5 @@
 """A data platform implementation that conforms to the DatabaseInterface."""
 import datetime as dt
-import logging
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
@@ -13,22 +12,7 @@ from timezonefinder import timezone_at
 from typing_extensions import override
 
 from quartz_api.internal import models
-
-log = logging.getLogger("dataplatform.client")
-
-HUBSPOT_COMPANY_ID_KEY = "hubspot_company_id"
-
-
-def get_org_id_from_authdata(authdata: dict[str, str]) -> str | None:
-    """Extract the HubSpot company ID from JWT app_metadata claims.
-
-    The JWT contains app_metadata with hubspot_company_id which maps
-    to organisation_id_filter in the Data Platform.
-    """
-    app_metadata = authdata.get("app_metadata", {})
-    if isinstance(app_metadata, dict):
-        return app_metadata.get("hubspot_company_id")
-    return None
+from quartz_api.internal.middleware.auth import get_org_id_from_authdata
 
 energy_type_map: dict[models.EnergyType, common_pb2.EnergySource] = {
     models.EnergyType.SOLAR: common_pb2.EnergySource.ENERGY_SOURCE_SOLAR,

--- a/src/quartz_api/internal/backends/dataplatform/client.py
+++ b/src/quartz_api/internal/backends/dataplatform/client.py
@@ -271,7 +271,7 @@ class StorageClient(models.StorageInterface):
         if observer_name is None:
             raise ValueError("Observer must be specified for data platform backend.")
 
-        if authdata != {} and location_type == models.LocationType.SITE:
+        if authdata != {}:
             _ = await self._check_user_access(
                 location_uuid=location_uuid,
                 energy_source=energy_type_map[energy_type],
@@ -320,7 +320,7 @@ class StorageClient(models.StorageInterface):
         if not generation_values:
             return
 
-        if authdata != {} and location_type == models.LocationType.SITE:
+        if authdata != {}:
             _ = await self._check_user_access(
                 location_uuid=location_uuid,
                 energy_source=energy_type_map[energy_type],

--- a/src/quartz_api/internal/backends/dataplatform/client.py
+++ b/src/quartz_api/internal/backends/dataplatform/client.py
@@ -467,7 +467,9 @@ class StorageClient(models.StorageInterface):
                 organisation_id = None
             case _, models.LocationType.SUBSTATION:
                 # get substations had optional auth (?) (temporary while we onboard?)
-                organisation_id = None
+                organisation_id = (
+                    get_org_id_from_authdata(authdata) if authdata != {} else None
+                )
             case _, models.LocationType.SITE:
                 # get_sites had auth (HubSpot company ID)
                 organisation_id = (

--- a/src/quartz_api/internal/backends/dataplatform/test_client.py
+++ b/src/quartz_api/internal/backends/dataplatform/test_client.py
@@ -20,9 +20,10 @@ def mock_list_locations(
     req: messages_pb2.ListLocationsRequest,
     metadata: object | None = None,
 ) -> messages_pb2.ListLocationsResponse:
-    if req.location_type_filter == common_pb2.LocationType.LOCATION_TYPE_GSP:
-        pass
-    elif req.organisation_id_filter != "access_org":
+    if (
+        req.location_type_filter == common_pb2.LOCATION_TYPE_SITE
+        and req.organisation_id_filter != "access_org"
+    ):
         return messages_pb2.ListLocationsResponse(locations=[])
 
     match req.location_type_filter:
@@ -315,9 +316,9 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
                 expected_num_substations=1,
             ),
             TestCase(
-                name="Should return no substations when user has no access",
+                name="Should return substations even when user has no access",
                 authdata={"app_metadata": {"hubspot_company_id": "no_access_org"}},
-                expected_num_substations=0,
+                expected_num_substations=1,
             ),
         ]
 
@@ -353,11 +354,11 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
                 number_of_locations=1,
             ),
             TestCase(
-                name="Should raise HTTPException when user has no access",
+                name="Should return substation even when user has no access",
                 location_uuid=uuid.uuid4(),
                 authdata={"app_metadata": {"hubspot_company_id": "no_access_org"}},
                 should_error=False,
-                number_of_locations=0,
+                number_of_locations=1,
             ),
         ]
 
@@ -409,11 +410,11 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
                 should_error=False,
             ),
             TestCase(
-                name="Should raise HTTPException when user has no access",
+                name="Should return GSP-scaled forecast even when user has no access",
                 substation_uuid=uuid.uuid4(),
                 authdata={"app_metadata": {"hubspot_company_id": "no_access_org"}},
-                expected_values=[],
-                should_error=True,
+                expected_values=[50] * 5,
+                should_error=False,
             ),
         ]
 

--- a/src/quartz_api/internal/backends/dataplatform/test_client.py
+++ b/src/quartz_api/internal/backends/dataplatform/test_client.py
@@ -20,7 +20,9 @@ def mock_list_locations(
     req: messages_pb2.ListLocationsRequest,
     metadata: object | None = None,
 ) -> messages_pb2.ListLocationsResponse:
-    if req.user_oauth_id_filter != "access_user":
+    if req.location_type_filter == common_pb2.LocationType.LOCATION_TYPE_GSP:
+        pass
+    elif req.organisation_id_filter != "access_org":
         return messages_pb2.ListLocationsResponse(locations=[])
 
     match req.location_type_filter:
@@ -162,12 +164,12 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
         testcases: list[TestCase] = [
             TestCase(
                 name="Should return locations when user has access",
-                authdata={"sub": "access_user"},
+                authdata={"app_metadata": {"hubspot_company_id": "access_org"}},
                 expected_num_locations=1,
             ),
             TestCase(
                 name="Should return no locations when user has no access",
-                authdata={"sub": "no_access_user"},
+                authdata={"app_metadata": {"hubspot_company_id": "no_access_org"}},
                 expected_num_locations=0,
             ),
         ]
@@ -198,13 +200,13 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
             TestCase(
                 name="Should return forecast when user has access",
                 site_uuid=uuid.uuid4(),
-                authdata={"sub": "access_user"},
+                authdata={"app_metadata": {"hubspot_company_id": "access_org"}},
                 should_error=False,
             ),
             TestCase(
                 name="Should raise HTTPException when user has no access",
                 site_uuid=uuid.uuid4(),
-                authdata={"sub": "no_access_user"},
+                authdata={"app_metadata": {"hubspot_company_id": "no_access_org"}},
                 should_error=True,
             ),
         ]
@@ -253,13 +255,13 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
             TestCase(
                 name="Should return generation when user has access",
                 site_uuid=uuid.uuid4(),
-                authdata={"sub": "access_user"},
+                authdata={"app_metadata": {"hubspot_company_id": "access_org"}},
                 should_error=False,
             ),
             TestCase(
                 name="Should raise HTTPException when user has no access",
                 site_uuid=uuid.uuid4(),
-                authdata={"sub": "no_access_user"},
+                authdata={"app_metadata": {"hubspot_company_id": "no_access_org"}},
                 should_error=True,
             ),
         ]
@@ -309,12 +311,12 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
         testcases: list[TestCase] = [
             TestCase(
                 name="Should return substations when user has access",
-                authdata={"sub": "access_user"},
+                authdata={"app_metadata": {"hubspot_company_id": "access_org"}},
                 expected_num_substations=1,
             ),
             TestCase(
                 name="Should return no substations when user has no access",
-                authdata={"sub": "no_access_user"},
+                authdata={"app_metadata": {"hubspot_company_id": "no_access_org"}},
                 expected_num_substations=0,
             ),
         ]
@@ -346,14 +348,14 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
             TestCase(
                 name="Should return substation when user has access",
                 location_uuid=uuid.uuid4(),
-                authdata={"sub": "access_user"},
+                authdata={"app_metadata": {"hubspot_company_id": "access_org"}},
                 should_error=False,
                 number_of_locations=1,
             ),
             TestCase(
                 name="Should raise HTTPException when user has no access",
                 location_uuid=uuid.uuid4(),
-                authdata={"sub": "no_access_user"},
+                authdata={"app_metadata": {"hubspot_company_id": "no_access_org"}},
                 should_error=False,
                 number_of_locations=0,
             ),
@@ -399,7 +401,7 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
             TestCase(
                 name="Should return GSP-scaled forecast when user has access",
                 substation_uuid=uuid.uuid4(),
-                authdata={"sub": "access_user"},
+                authdata={"app_metadata": {"hubspot_company_id": "access_org"}},
                 # The forecast returns 5e5 watts for every value, and the substation's
                 # effective capacity is 1e5 watts (10% of the GSP's 1e6 watts), so
                 # the scaled values should be 0.1*5e5W = 50kW for each entry.
@@ -409,7 +411,7 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
             TestCase(
                 name="Should raise HTTPException when user has no access",
                 substation_uuid=uuid.uuid4(),
-                authdata={"sub": "no_access_user"},
+                authdata={"app_metadata": {"hubspot_company_id": "no_access_org"}},
                 expected_values=[],
                 should_error=True,
             ),
@@ -469,7 +471,7 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
                 location_uuids=test_uuids,
                 snapshot_timestamp_utc=TEST_TIMESTAMP_UTC,
                 energy_type=models.EnergyType.SOLAR,
-                authdata={"sub": "access_user"},
+                authdata={"app_metadata": {"hubspot_company_id": "access_org"}},
                 forecaster_name=None,
             )
 
@@ -477,7 +479,7 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
             location_uuids=test_uuids,
             snapshot_timestamp_utc=TEST_TIMESTAMP_UTC,
             energy_type=models.EnergyType.SOLAR,
-            authdata={"sub": "access_user"},
+            authdata={"app_metadata": {"hubspot_company_id": "access_org"}},
             forecaster_name="blend",
             # forecaster_version is omitted to force ListForecasters call
         )
@@ -504,7 +506,7 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
                 location_uuids=test_uuids,
                 snapshot_timestamp_utc=TEST_TIMESTAMP_UTC,
                 energy_type=models.EnergyType.SOLAR,
-                authdata={"sub": "access_user"},
+                authdata={"app_metadata": {"hubspot_company_id": "access_org"}},
                 observer_name=None,
             )
 
@@ -512,7 +514,7 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
             location_uuids=test_uuids,
             snapshot_timestamp_utc=TEST_TIMESTAMP_UTC,
             energy_type=models.EnergyType.SOLAR,
-            authdata={"sub": "access_user"},
+            authdata={"app_metadata": {"hubspot_company_id": "access_org"}},
             observer_name="test_observer",
         )
 
@@ -533,6 +535,8 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
                 valid_timestamp=TEST_TIMESTAMP_UTC,
                 location_uuid=site_uuid,
                 capacity_kilowatts=0,
+                # observer_name is hardcoded at the router layer for now.
+                # TODO: derive from site metadata organization_id once DP migration is complete.
                 observer_name="ruvnl",
             ),
         ]
@@ -548,7 +552,7 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
             location_uuid=site_uuid,
             energy_type=models.EnergyType.SOLAR,
             location_type=models.LocationType.SITE,
-            authdata={"sub": "access_user"},
+            authdata={"app_metadata": {"hubspot_company_id": "access_org"}},
         )
         client_mock.CreateObservations.assert_called_once()
         sent = client_mock.CreateObservations.call_args.args[0]
@@ -563,7 +567,7 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
                 location_uuid=site_uuid,
                 energy_type=models.EnergyType.SOLAR,
                 location_type=models.LocationType.SITE,
-                authdata={"sub": "no_access_user"},
+                authdata={"app_metadata": {"hubspot_company_id": "no_access_org"}},
             )
 
     @patch("ocf.dp.dp_data.service_pb2_grpc.DataPlatformDataServiceStub")
@@ -609,7 +613,7 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
             location=loc,
             location_type=models.LocationType.SITE,
             energy_type=models.EnergyType.SOLAR,
-            authdata={"sub": "access_user"},
+            authdata={"app_metadata": {"hubspot_company_id": "access_org"}},
         )
         # Capacity round-trips kW -> watts -> kW, and lat/lng come from the fetched location.
         self.assertEqual(resp.capacity_kilowatts, 5.0)
@@ -628,7 +632,7 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
             location=loc,
             location_type=models.LocationType.SITE,
             energy_type=models.EnergyType.SOLAR,
-            authdata={"sub": "no_access_user"},
+            authdata={"app_metadata": {"hubspot_company_id": "no_access_org"}},
         )
         self.assertNotEqual(created.uuid, site_uuid)
         self.assertEqual(created.capacity_kilowatts, 5.0)

--- a/src/quartz_api/internal/backends/dataplatform/test_client.py
+++ b/src/quartz_api/internal/backends/dataplatform/test_client.py
@@ -21,10 +21,14 @@ def mock_list_locations(
     metadata: object | None = None,
 ) -> messages_pb2.ListLocationsResponse:
     if (
-        req.location_type_filter == common_pb2.LOCATION_TYPE_SITE
+        req.location_type_filter in (
+            common_pb2.LOCATION_TYPE_SITE,
+            common_pb2.LocationType.LOCATION_TYPE_PRIMARY_SUBSTATION,
+        )
         and req.organisation_id_filter != "access_org"
     ):
         return messages_pb2.ListLocationsResponse(locations=[])
+
 
     match req.location_type_filter:
         case common_pb2.LOCATION_TYPE_SITE:
@@ -316,9 +320,9 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
                 expected_num_substations=1,
             ),
             TestCase(
-                name="Should return substations even when user has no access",
+                name="Should return no substations when user has no access",
                 authdata={"app_metadata": {"hubspot_company_id": "no_access_org"}},
-                expected_num_substations=1,
+                expected_num_substations=0,
             ),
         ]
 
@@ -354,11 +358,11 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
                 number_of_locations=1,
             ),
             TestCase(
-                name="Should return substation even when user has no access",
+                name="Should raise HTTPException when user has no access",
                 location_uuid=uuid.uuid4(),
                 authdata={"app_metadata": {"hubspot_company_id": "no_access_org"}},
                 should_error=False,
-                number_of_locations=1,
+                number_of_locations=0,
             ),
         ]
 
@@ -410,11 +414,11 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
                 should_error=False,
             ),
             TestCase(
-                name="Should return GSP-scaled forecast even when user has no access",
+                name="Should raise HTTPException when user has no access",
                 substation_uuid=uuid.uuid4(),
                 authdata={"app_metadata": {"hubspot_company_id": "no_access_org"}},
-                expected_values=[50] * 5,
-                should_error=False,
+                expected_values=[],
+                should_error=True,
             ),
         ]
 

--- a/src/quartz_api/internal/backends/dummydb/client.py
+++ b/src/quartz_api/internal/backends/dummydb/client.py
@@ -158,6 +158,44 @@ class StorageClient(models.StorageInterface):
                     )
                     for n in ["dummy_wind_region1", "dummy_wind_region2"]
                 ]
+            case _, models.LocationType.SITE if energy_type is None:
+                # energy_type=None means "return all energy types" — used by sites router
+                locations = [
+                    models.Location(
+                        uuid=loc_uuid,
+                        name="Dummy Wind Site",
+                        latitude=23.25,
+                        longitude=69.25,
+                        capacity_kilowatts=300000,
+                        location_type=models.LocationType.SITE,
+                        energy_type=models.EnergyType.WIND,
+                    ),
+                    models.Location(
+                        uuid=uuid4(),
+                        name="Dummy Solar Site",
+                        latitude=26.0,
+                        longitude=76.0,
+                        capacity_kilowatts=5000,
+                        location_type=models.LocationType.SITE,
+                        energy_type=models.EnergyType.SOLAR,
+                    ),
+                ]
+                if location_uuid is not None:
+                    # Filter to just the requested UUID
+                    locations = [loc for loc in locations if loc.uuid == location_uuid]
+                    if not locations:
+                        # UUID not found — return a single match with the requested UUID
+                        locations = [
+                            models.Location(
+                                uuid=location_uuid,
+                                name="Dummy Wind Site",
+                                latitude=23.25,
+                                longitude=69.25,
+                                capacity_kilowatts=300000,
+                                location_type=models.LocationType.SITE,
+                                energy_type=models.EnergyType.WIND,
+                            ),
+                        ]
             case _, models.LocationType.SITE:
                 locations = [
                     models.Location(
@@ -167,6 +205,7 @@ class StorageClient(models.StorageInterface):
                         longitude=76,
                         capacity_kilowatts=76000,
                         location_type=models.LocationType.SITE,
+                        energy_type=energy_type,
                     ),
                 ]
             case _, models.LocationType.GSP:

--- a/src/quartz_api/internal/middleware/auth.py
+++ b/src/quartz_api/internal/middleware/auth.py
@@ -109,6 +109,18 @@ def get_oauth_id_from_sub(auth0_sub: str) -> str:
     return auth0_sub.split("|")[1]
 
 
+def get_org_id_from_authdata(authdata: dict) -> str | None:
+    """Extract the HubSpot company ID from JWT app_metadata claims.
+
+    The JWT contains app_metadata with hubspot_company_id which maps
+    to organisation_id_filter in the Data Platform.
+    """
+    app_metadata = authdata.get("app_metadata", {})
+    if isinstance(app_metadata, dict):
+        return app_metadata.get("hubspot_company_id")
+    return None
+
+
 def make_api_auth_description(domain: str, audience: str, host_url: str, client_id: str) -> str:
     """Generate API authentication description."""
     # note that the odd indentation here is needed for to make the f-string and markdown work

--- a/src/quartz_api/internal/models/db_interface.py
+++ b/src/quartz_api/internal/models/db_interface.py
@@ -73,6 +73,7 @@ class Location:
     longitude: float
     capacity_kilowatts: float
     location_type: LocationType | None = None
+    energy_type: EnergyType | None = None
     metadata: dict[str, str | int | float] = dataclasses.field(default_factory=dict)
 
 
@@ -171,7 +172,7 @@ class StorageInterface(abc.ABC):
     @abc.abstractmethod
     async def get_locations(
         self,
-        energy_type: EnergyType,
+        energy_type: EnergyType | None,
         location_type: LocationType | None,
         authdata: dict[str, str],
         location_uuid: UUID | None = None,
@@ -180,6 +181,7 @@ class StorageInterface(abc.ABC):
     ) -> list[Location]:
         """Return a list of locations for a given energy and location type.
 
+        If energy_type is None, locations of all energy types are returned.
         If location_type is None, locations of all types are returned.
         If enclosing_location_uuid is provided, only locations enclosed by that
         location (i.e. children/descendants) are returned.

--- a/src/quartz_api/internal/service/sites/router.py
+++ b/src/quartz_api/internal/service/sites/router.py
@@ -1,7 +1,6 @@
 """The 'sites' FastAPI router object and associated routes logic."""
 
 import datetime as dt
-import logging
 import pathlib
 from uuid import UUID
 
@@ -11,55 +10,8 @@ from starlette import status
 
 from quartz_api.internal import models
 from quartz_api.internal.middleware.auth import AuthDependency
-from quartz_api.internal.service.v1.country_config import COUNTRIES
 
 from .endpoint_types import ActualPower, PredictedPower, Site, SiteProperties
-
-log = logging.getLogger(__name__)
-
-# Maps DP site-name prefixes to country codes in COUNTRIES.
-# Add entries here as new countries are onboarded to the sites API.
-_SITE_PREFIX_TO_COUNTRY: dict[str, str] = {
-    "ind_": "IN",
-    "ad_": "IN",   # Adani sites also belong to India
-}
-
-
-def _resolve_observer_name(
-    site: models.Location,
-    energy_type: models.EnergyType,
-    fallback: str = "ind_rajasthan",
-) -> str:
-    """Return the DP observer_name for a site, derived from the V1 CountryConfig.
-
-    Looks up the site's name prefix in _SITE_PREFIX_TO_COUNTRY to find the
-    matching CountryConfig, then picks the first GenerationSource whose source
-    matches the energy type ("solar" or "wind").
-
-    Falls back to *fallback* with a warning if no match is found.
-    """
-    source = "solar" if energy_type == models.EnergyType.SOLAR else "wind"
-    for prefix, country_code in _SITE_PREFIX_TO_COUNTRY.items():
-        if site.name.startswith(prefix):
-            country = COUNTRIES.get(country_code)
-            if country is None:
-                break
-            for gs in country.generation_sources:
-                if gs.source == source:
-                    return gs.name
-            # Country found but no matching source type — use first available
-            if country.generation_sources:
-                return country.generation_sources[0].name
-            break
-    log.warning(
-        "Could not resolve observer_name for site '%s' (energy_type=%s); "
-        "falling back to '%s'",
-        site.name,
-        energy_type,
-        fallback,
-    )
-    return fallback
-
 
 router = APIRouter(tags=[pathlib.Path(__file__).parent.stem.capitalize()])
 
@@ -216,14 +168,16 @@ async def get_generation(
     tz: models.TZDependency,
 ) -> list[ActualPower]:
     """Get generation of a site (Solar or Wind, auto-detected)."""
+    # TODO: observer_name should be derived from the site's organization_id metadata
+    # in the data platform (via get_locations -> location.metadata["organization_id"]).
+    # Hardcoded for now until the DP migration is complete.
+    observer_name = "ind_rajasthan"
     site = await _get_site_with_energy_type(db, site_uuid, auth)
-    energy_type = site.energy_type or models.EnergyType.SOLAR
-    observer_name = _resolve_observer_name(site, energy_type)
     agvs = await db.get_actual_generation(
         location_uuid=site_uuid,
         window_start=pd.Timestamp.now(tz=tz).floor("H").to_pydatetime() - dt.timedelta(days=2),
         window_end=pd.Timestamp.now(tz=tz).floor("H").to_pydatetime() + dt.timedelta(days=2),
-        energy_type=energy_type,
+        energy_type=site.energy_type or models.EnergyType.SOLAR,
         location_type=models.LocationType.SITE,
         authdata=auth,
         observer_name=observer_name,
@@ -279,16 +233,17 @@ async def post_generation(
     **Note**: Users should wait up to 1 day(s) to start experiencing the full
     effects from using live PV data.
     """
+    # TODO: observer_name should be derived from the site's organization_id metadata
+    # in the data platform (via get_locations -> location.metadata["organization_id"]).
+    # Hardcoded for now until the DP migration is complete.
     site = await _get_site_with_energy_type(db, site_uuid, auth)
-    energy_type = site.energy_type or models.EnergyType.SOLAR
-    observer_name = _resolve_observer_name(site, energy_type)
     agvs: list[models.ActualGenerationValue] = [
         models.ActualGenerationValue(
             power_kilowatts=g.PowerKW,
             valid_timestamp=g.Time,
             location_uuid=site_uuid,
             capacity_kilowatts=0,  # NOTE: This is ignored when writing
-            observer_name=observer_name,
+            observer_name="ind_rajasthan",  # TODO: presumably this could change based on user input
         )
         for g in generation
     ]

--- a/src/quartz_api/internal/service/sites/router.py
+++ b/src/quartz_api/internal/service/sites/router.py
@@ -15,6 +15,10 @@ from .endpoint_types import ActualPower, PredictedPower, Site, SiteProperties
 
 router = APIRouter(tags=[pathlib.Path(__file__).parent.stem.capitalize()])
 
+# Observer name used when reading/writing site-level generation data.
+# TODO: should be derived per-site from organisation metadata once DP migration is complete.
+SITE_OBSERVER_NAME = "site_api"
+
 
 async def _get_site_with_energy_type(
     db: models.StorageInterface,
@@ -168,10 +172,7 @@ async def get_generation(
     tz: models.TZDependency,
 ) -> list[ActualPower]:
     """Get generation of a site (Solar or Wind, auto-detected)."""
-    # TODO: observer_name should be derived from the site's organization_id metadata
-    # in the data platform (via get_locations -> location.metadata["organization_id"]).
-    # Hardcoded for now until the DP migration is complete.
-    observer_name = "site_api"
+    observer_name = SITE_OBSERVER_NAME
     site = await _get_site_with_energy_type(db, site_uuid, auth)
     agvs = await db.get_actual_generation(
         location_uuid=site_uuid,
@@ -243,7 +244,7 @@ async def post_generation(
             valid_timestamp=g.Time,
             location_uuid=site_uuid,
             capacity_kilowatts=0,  # NOTE: This is ignored when writing
-            observer_name="site_api",  # TODO: presumably this could change based on user input
+            observer_name=SITE_OBSERVER_NAME,
         )
         for g in generation
     ]

--- a/src/quartz_api/internal/service/sites/router.py
+++ b/src/quartz_api/internal/service/sites/router.py
@@ -1,6 +1,7 @@
 """The 'sites' FastAPI router object and associated routes logic."""
 
 import datetime as dt
+import logging
 import pathlib
 from uuid import UUID
 
@@ -10,8 +11,55 @@ from starlette import status
 
 from quartz_api.internal import models
 from quartz_api.internal.middleware.auth import AuthDependency
+from quartz_api.internal.service.v1.country_config import COUNTRIES
 
 from .endpoint_types import ActualPower, PredictedPower, Site, SiteProperties
+
+log = logging.getLogger(__name__)
+
+# Maps DP site-name prefixes to country codes in COUNTRIES.
+# Add entries here as new countries are onboarded to the sites API.
+_SITE_PREFIX_TO_COUNTRY: dict[str, str] = {
+    "ind_": "IN",
+    "ad_": "IN",   # Adani sites also belong to India
+}
+
+
+def _resolve_observer_name(
+    site: models.Location,
+    energy_type: models.EnergyType,
+    fallback: str = "ind_rajasthan",
+) -> str:
+    """Return the DP observer_name for a site, derived from the V1 CountryConfig.
+
+    Looks up the site's name prefix in _SITE_PREFIX_TO_COUNTRY to find the
+    matching CountryConfig, then picks the first GenerationSource whose source
+    matches the energy type ("solar" or "wind").
+
+    Falls back to *fallback* with a warning if no match is found.
+    """
+    source = "solar" if energy_type == models.EnergyType.SOLAR else "wind"
+    for prefix, country_code in _SITE_PREFIX_TO_COUNTRY.items():
+        if site.name.startswith(prefix):
+            country = COUNTRIES.get(country_code)
+            if country is None:
+                break
+            for gs in country.generation_sources:
+                if gs.source == source:
+                    return gs.name
+            # Country found but no matching source type — use first available
+            if country.generation_sources:
+                return country.generation_sources[0].name
+            break
+    log.warning(
+        "Could not resolve observer_name for site '%s' (energy_type=%s); "
+        "falling back to '%s'",
+        site.name,
+        energy_type,
+        fallback,
+    )
+    return fallback
+
 
 router = APIRouter(tags=[pathlib.Path(__file__).parent.stem.capitalize()])
 
@@ -168,16 +216,14 @@ async def get_generation(
     tz: models.TZDependency,
 ) -> list[ActualPower]:
     """Get generation of a site (Solar or Wind, auto-detected)."""
-    # TODO: observer_name should be derived from the site's organization_id metadata
-    # in the data platform (via get_locations -> location.metadata["organization_id"]).
-    # Hardcoded for now until the DP migration is complete.
-    observer_name = "ind_rajasthan"
     site = await _get_site_with_energy_type(db, site_uuid, auth)
+    energy_type = site.energy_type or models.EnergyType.SOLAR
+    observer_name = _resolve_observer_name(site, energy_type)
     agvs = await db.get_actual_generation(
         location_uuid=site_uuid,
         window_start=pd.Timestamp.now(tz=tz).floor("H").to_pydatetime() - dt.timedelta(days=2),
         window_end=pd.Timestamp.now(tz=tz).floor("H").to_pydatetime() + dt.timedelta(days=2),
-        energy_type=site.energy_type or models.EnergyType.SOLAR,
+        energy_type=energy_type,
         location_type=models.LocationType.SITE,
         authdata=auth,
         observer_name=observer_name,
@@ -233,17 +279,16 @@ async def post_generation(
     **Note**: Users should wait up to 1 day(s) to start experiencing the full
     effects from using live PV data.
     """
-    # TODO: observer_name should be derived from the site's organization_id metadata
-    # in the data platform (via get_locations -> location.metadata["organization_id"]).
-    # Hardcoded for now until the DP migration is complete.
     site = await _get_site_with_energy_type(db, site_uuid, auth)
+    energy_type = site.energy_type or models.EnergyType.SOLAR
+    observer_name = _resolve_observer_name(site, energy_type)
     agvs: list[models.ActualGenerationValue] = [
         models.ActualGenerationValue(
             power_kilowatts=g.PowerKW,
             valid_timestamp=g.Time,
             location_uuid=site_uuid,
             capacity_kilowatts=0,  # NOTE: This is ignored when writing
-            observer_name="ind_rajasthan",  # TODO: presumably this could change based on user input
+            observer_name=observer_name,
         )
         for g in generation
     ]

--- a/src/quartz_api/internal/service/sites/router.py
+++ b/src/quartz_api/internal/service/sites/router.py
@@ -171,7 +171,7 @@ async def get_generation(
     # TODO: observer_name should be derived from the site's organization_id metadata
     # in the data platform (via get_locations -> location.metadata["organization_id"]).
     # Hardcoded for now until the DP migration is complete.
-    observer_name = "ind_rajasthan"
+    observer_name = "site_api"
     site = await _get_site_with_energy_type(db, site_uuid, auth)
     agvs = await db.get_actual_generation(
         location_uuid=site_uuid,
@@ -243,7 +243,7 @@ async def post_generation(
             valid_timestamp=g.Time,
             location_uuid=site_uuid,
             capacity_kilowatts=0,  # NOTE: This is ignored when writing
-            observer_name="ind_rajasthan",  # TODO: presumably this could change based on user input
+            observer_name="site_api",  # TODO: presumably this could change based on user input
         )
         for g in generation
     ]

--- a/src/quartz_api/internal/service/sites/router.py
+++ b/src/quartz_api/internal/service/sites/router.py
@@ -5,7 +5,7 @@ import pathlib
 from uuid import UUID
 
 import pandas as pd
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from starlette import status
 
 from quartz_api.internal import models
@@ -15,8 +15,29 @@ from .endpoint_types import ActualPower, PredictedPower, Site, SiteProperties
 
 router = APIRouter(tags=[pathlib.Path(__file__).parent.stem.capitalize()])
 
-# TODO: I'm not sure if the inputs here are strictly solar only. If not, I need to find a way to
-# work out which type is desired.
+
+async def _get_site_with_energy_type(
+    db: models.StorageInterface,
+    site_uuid: UUID,
+    authdata: dict,
+) -> models.Location:
+    """Fetch a single site and return it with its energy_type populated.
+
+    Calls the DP without an energy_source_filter so both SOLAR and WIND are
+    considered in one round-trip. Raises HTTP 404 if not found.
+    """
+    locs = await db.get_locations(
+        energy_type=None,  # no filter → returns SOLAR and WIND
+        location_type=models.LocationType.SITE,
+        authdata=authdata,
+        location_uuid=site_uuid,
+    )
+    if not locs:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No site found for UUID '{site_uuid}'.",
+        )
+    return locs[0]
 
 
 @router.get(
@@ -27,9 +48,9 @@ async def get_sites(
     db: models.StorageClientDependency,
     auth: AuthDependency,
 ) -> list[Site]:
-    """Get sites."""
+    """Get all sites (Solar and Wind) visible to the authenticated user."""
     sites = await db.get_locations(
-        energy_type=models.EnergyType.SOLAR,
+        energy_type=None,  # no filter → returns both SOLAR and WIND
         location_type=models.LocationType.SITE,
         authdata=auth,
     )
@@ -64,6 +85,7 @@ async def put_site_info(
         You can update one or more fields at a time. For example :
         {"orientation": 170, "tilt": 35, "capacity_kw": 5}
     """
+    existing = await _get_site_with_energy_type(db, site_uuid, auth)
     loc: models.Location = models.Location(
         uuid=site_uuid,
         name=site_info.client_site_name,
@@ -83,7 +105,7 @@ async def put_site_info(
     )
     site = await db.put_location(
         location=loc,
-        energy_type=models.EnergyType.SOLAR,
+        energy_type=existing.energy_type or models.EnergyType.SOLAR,
         location_type=models.LocationType.SITE,
         authdata=auth,
     )
@@ -109,12 +131,13 @@ async def get_forecast(
     auth: AuthDependency,
     tz: models.TZDependency,
 ) -> list[PredictedPower]:
-    """Get forecast of a site."""
+    """Get forecast of a site (Solar or Wind, auto-detected)."""
+    site = await _get_site_with_energy_type(db, site_uuid, auth)
     pgvs = await db.get_predicted_generation(
         location_uuid=site_uuid,
         window_start=pd.Timestamp.now(tz=tz).floor("H").to_pydatetime() - dt.timedelta(days=2),
         window_end=pd.Timestamp.now(tz=tz).floor("H").to_pydatetime() + dt.timedelta(days=2),
-        energy_type=models.EnergyType.SOLAR,
+        energy_type=site.energy_type or models.EnergyType.SOLAR,
         location_type=models.LocationType.SITE,
         authdata=auth,
     )
@@ -144,14 +167,20 @@ async def get_generation(
     auth: AuthDependency,
     tz: models.TZDependency,
 ) -> list[ActualPower]:
-    """Get get generation fo a site."""
+    """Get generation of a site (Solar or Wind, auto-detected)."""
+    # TODO: observer_name should be derived from the site's organization_id metadata
+    # in the data platform (via get_locations -> location.metadata["organization_id"]).
+    # Hardcoded for now until the DP migration is complete.
+    observer_name = "ind_rajasthan"
+    site = await _get_site_with_energy_type(db, site_uuid, auth)
     agvs = await db.get_actual_generation(
         location_uuid=site_uuid,
         window_start=pd.Timestamp.now(tz=tz).floor("H").to_pydatetime() - dt.timedelta(days=2),
         window_end=pd.Timestamp.now(tz=tz).floor("H").to_pydatetime() + dt.timedelta(days=2),
-        energy_type=models.EnergyType.SOLAR,
+        energy_type=site.energy_type or models.EnergyType.SOLAR,
         location_type=models.LocationType.SITE,
         authdata=auth,
+        observer_name=observer_name,
     )
     out: list[ActualPower] = [
         ActualPower(
@@ -204,13 +233,17 @@ async def post_generation(
     **Note**: Users should wait up to 1 day(s) to start experiencing the full
     effects from using live PV data.
     """
+    # TODO: observer_name should be derived from the site's organization_id metadata
+    # in the data platform (via get_locations -> location.metadata["organization_id"]).
+    # Hardcoded for now until the DP migration is complete.
+    site = await _get_site_with_energy_type(db, site_uuid, auth)
     agvs: list[models.ActualGenerationValue] = [
         models.ActualGenerationValue(
             power_kilowatts=g.PowerKW,
             valid_timestamp=g.Time,
             location_uuid=site_uuid,
             capacity_kilowatts=0,  # NOTE: This is ignored when writing
-            observer_name="ruvnl",  # TODO: presumably this could change based on user input
+            observer_name="ind_rajasthan",  # TODO: presumably this could change based on user input
         )
         for g in generation
     ]
@@ -218,7 +251,7 @@ async def post_generation(
     await db.put_actual_generation(
         location_uuid=site_uuid,
         generation_values=agvs,
-        energy_type=models.EnergyType.SOLAR,
+        energy_type=site.energy_type or models.EnergyType.SOLAR,
         location_type=models.LocationType.SITE,
         authdata=auth,
     )

--- a/src/quartz_api/internal/service/sites/test_router.py
+++ b/src/quartz_api/internal/service/sites/test_router.py
@@ -1,0 +1,375 @@
+"""Unit tests for the sites router endpoints.
+
+Tests cover:
+- GET /sites          — lists all SOLAR + WIND sites for the authenticated org
+- GET /sites/{uuid}/forecast   — returns forecast for a valid site UUID
+- GET /sites/{uuid}/generation — returns generation data for a valid site UUID
+- GET /sites/{invalid}/forecast   — returns 404 for an unknown site UUID
+- GET /sites/{invalid}/generation — returns 404 for an unknown site UUID
+- POST /sites/{uuid}/generation   — persists generation data, returns 200
+- PUT  /sites/{uuid}              — updates site properties, returns 200
+"""
+
+# ruff: noqa: ARG002
+
+import typing
+from collections.abc import AsyncGenerator
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from quartz_api.internal import models
+from quartz_api.internal.backends.dummydb.client import StorageClient
+from quartz_api.internal.middleware.auth import AuthDependency
+
+from .router import router
+
+_auth_dep = typing.get_args(AuthDependency)[1].dependency
+
+# A fixed UUID used across tests so UUID-based lookups are predictable
+_WIND_SITE_UUID = uuid4()
+_SOLAR_SITE_UUID = uuid4()
+_UNKNOWN_UUID = uuid4()
+
+
+# ---------------------------------------------------------------------------
+# Mock storage clients
+# ---------------------------------------------------------------------------
+
+
+class SitesStorageClient(StorageClient):
+    """DummyDB variant that returns deterministic WIND + SOLAR sites.
+
+    When energy_type=None (no filter), returns both energy types so the
+    router's _get_site_with_energy_type() helper can detect the type.
+    When filtering by UUID, returns only the matching site.
+    """
+
+    async def get_locations(  # type: ignore[override]
+        self,
+        energy_type: models.EnergyType | None,
+        location_type: models.LocationType | None,
+        authdata: dict,
+        location_uuid: UUID | None = None,
+        enclosing_location_uuid: UUID | None = None,
+        location_names: list[str] | None = None,
+    ) -> list[models.Location]:
+        if location_type == models.LocationType.SITE and energy_type is None:
+            all_sites = [
+                models.Location(
+                    uuid=_WIND_SITE_UUID,
+                    name="ad_seci_5",
+                    latitude=23.25,
+                    longitude=69.25,
+                    capacity_kilowatts=300_000,
+                    location_type=models.LocationType.SITE,
+                    energy_type=models.EnergyType.WIND,
+                ),
+                models.Location(
+                    uuid=_SOLAR_SITE_UUID,
+                    name="dummy_solar_farm",
+                    latitude=26.0,
+                    longitude=76.0,
+                    capacity_kilowatts=5_000,
+                    location_type=models.LocationType.SITE,
+                    energy_type=models.EnergyType.SOLAR,
+                ),
+            ]
+            if location_uuid is not None:
+                return [s for s in all_sites if s.uuid == location_uuid]
+            return all_sites
+        return await super().get_locations(
+            energy_type=energy_type,
+            location_type=location_type,
+            authdata={},
+            location_uuid=location_uuid,
+            enclosing_location_uuid=enclosing_location_uuid,
+            location_names=location_names,
+        )
+
+
+class EmptySitesClient(SitesStorageClient):
+    """Returns an empty list for any SITE + energy_type=None query.
+
+    Simulates "no sites found" (e.g., unknown UUID or wrong org).
+    """
+
+    async def get_locations(  # type: ignore[override]
+        self,
+        energy_type: models.EnergyType | None,
+        location_type: models.LocationType | None,
+        authdata: dict,
+        location_uuid: UUID | None = None,
+        enclosing_location_uuid: UUID | None = None,
+        location_names: list[str] | None = None,
+    ) -> list[models.Location]:
+        if location_type == models.LocationType.SITE and energy_type is None:
+            return []
+        return await super().get_locations(
+            energy_type=energy_type,
+            location_type=location_type,
+            authdata=authdata,
+            location_uuid=location_uuid,
+            enclosing_location_uuid=enclosing_location_uuid,
+            location_names=location_names,
+        )
+
+
+# ---------------------------------------------------------------------------
+# App factory + fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_app(db: models.StorageInterface) -> FastAPI:
+    """Build a minimal FastAPI app wired to the sites router with dummy auth."""
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[models.get_storage_client] = lambda: db
+    app.dependency_overrides[_auth_dep] = lambda: {
+        "sub": "google-oauth2|108386900569835961988",
+        "app_metadata": {"hubspot_company_id": "99999999999"},
+        "permissions": ["read:india"],
+    }
+    return app
+
+
+@pytest_asyncio.fixture
+async def client() -> AsyncGenerator[AsyncClient, None]:
+    """Test client backed by SitesStorageClient — returns WIND + SOLAR sites."""
+    app = _make_app(SitesStorageClient())
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        yield ac
+
+
+@pytest_asyncio.fixture
+async def empty_client() -> AsyncGenerator[AsyncClient, None]:
+    """Test client that returns no sites for any query — simulates unknown org."""
+    app = _make_app(EmptySitesClient())
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        yield ac
+
+
+# ---------------------------------------------------------------------------
+# GET /sites
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_get_sites_returns_200(client: AsyncClient) -> None:
+    """GET /sites returns HTTP 200."""
+    resp = await client.get("/sites")
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_get_sites_returns_list(client: AsyncClient) -> None:
+    """GET /sites returns a JSON list."""
+    resp = await client.get("/sites")
+    assert isinstance(resp.json(), list)
+
+
+@pytest.mark.anyio
+async def test_get_sites_returns_both_solar_and_wind(client: AsyncClient) -> None:
+    """GET /sites returns sites of both energy types."""
+    resp = await client.get("/sites")
+    sites = resp.json()
+    assert len(sites) == 2
+    names = {s["client_site_name"] for s in sites}
+    assert "ad_seci_5" in names
+    assert "dummy_solar_farm" in names
+
+
+@pytest.mark.anyio
+async def test_get_sites_has_required_fields(client: AsyncClient) -> None:
+    """Each site in GET /sites has all required fields."""
+    resp = await client.get("/sites")
+    for site in resp.json():
+        assert "site_uuid" in site
+        assert "latitude" in site
+        assert "longitude" in site
+        assert "capacity_kW" in site
+        assert "client_site_name" in site
+
+
+@pytest.mark.anyio
+async def test_get_sites_empty_for_unknown_org(empty_client: AsyncClient) -> None:
+    """GET /sites returns an empty list when no sites match the org."""
+    resp = await empty_client.get("/sites")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# GET /sites/{uuid}/forecast — valid UUID
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_get_forecast_valid_wind_site_returns_200(client: AsyncClient) -> None:
+    """GET /sites/{uuid}/forecast returns 200 for a known WIND site UUID."""
+    resp = await client.get(f"/sites/{_WIND_SITE_UUID}/forecast")
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_get_forecast_valid_solar_site_returns_200(client: AsyncClient) -> None:
+    """GET /sites/{uuid}/forecast returns 200 for a known SOLAR site UUID."""
+    resp = await client.get(f"/sites/{_SOLAR_SITE_UUID}/forecast")
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_get_forecast_returns_list_of_values(client: AsyncClient) -> None:
+    """GET /sites/{uuid}/forecast returns a non-empty list of forecast values."""
+    resp = await client.get(f"/sites/{_WIND_SITE_UUID}/forecast")
+    body = resp.json()
+    assert isinstance(body, list)
+    assert len(body) > 0
+
+
+@pytest.mark.anyio
+async def test_get_forecast_values_have_required_fields(client: AsyncClient) -> None:
+    """Each forecast entry has PowerKW and Time fields."""
+    resp = await client.get(f"/sites/{_WIND_SITE_UUID}/forecast")
+    for entry in resp.json():
+        assert "PowerKW" in entry
+        assert "Time" in entry
+
+
+# ---------------------------------------------------------------------------
+# GET /sites/{uuid}/forecast — invalid UUID → 404
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_get_forecast_unknown_uuid_returns_404(empty_client: AsyncClient) -> None:
+    """GET /sites/{uuid}/forecast returns 404 for an unknown site UUID."""
+    resp = await empty_client.get(f"/sites/{_UNKNOWN_UUID}/forecast")
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_get_forecast_404_contains_uuid_in_detail(empty_client: AsyncClient) -> None:
+    """The 404 detail message includes the requested UUID."""
+    resp = await empty_client.get(f"/sites/{_UNKNOWN_UUID}/forecast")
+    assert str(_UNKNOWN_UUID) in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# GET /sites/{uuid}/generation — valid UUID
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_get_generation_valid_wind_site_returns_200(client: AsyncClient) -> None:
+    """GET /sites/{uuid}/generation returns 200 for a known WIND site UUID."""
+    resp = await client.get(f"/sites/{_WIND_SITE_UUID}/generation")
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_get_generation_valid_solar_site_returns_200(client: AsyncClient) -> None:
+    """GET /sites/{uuid}/generation returns 200 for a known SOLAR site UUID."""
+    resp = await client.get(f"/sites/{_SOLAR_SITE_UUID}/generation")
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_get_generation_returns_list(client: AsyncClient) -> None:
+    """GET /sites/{uuid}/generation returns a list."""
+    resp = await client.get(f"/sites/{_WIND_SITE_UUID}/generation")
+    assert isinstance(resp.json(), list)
+
+
+@pytest.mark.anyio
+async def test_get_generation_values_have_required_fields(client: AsyncClient) -> None:
+    """Each generation entry has PowerKW and Time fields."""
+    resp = await client.get(f"/sites/{_WIND_SITE_UUID}/generation")
+    for entry in resp.json():
+        assert "PowerKW" in entry
+        assert "Time" in entry
+
+
+# ---------------------------------------------------------------------------
+# GET /sites/{uuid}/generation — invalid UUID → 404
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_get_generation_unknown_uuid_returns_404(empty_client: AsyncClient) -> None:
+    """GET /sites/{uuid}/generation returns 404 for an unknown site UUID."""
+    resp = await empty_client.get(f"/sites/{_UNKNOWN_UUID}/generation")
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_get_generation_404_contains_uuid_in_detail(empty_client: AsyncClient) -> None:
+    """The 404 detail message includes the requested UUID."""
+    resp = await empty_client.get(f"/sites/{_UNKNOWN_UUID}/generation")
+    assert str(_UNKNOWN_UUID) in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# POST /sites/{uuid}/generation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_post_generation_valid_site_returns_200(client: AsyncClient) -> None:
+    """POST /sites/{uuid}/generation returns 200 for a known site UUID."""
+    payload = [
+        {"PowerKW": 150.5, "Time": "2026-06-19T08:00:00Z"},
+        {"PowerKW": 175.0, "Time": "2026-06-19T08:15:00Z"},
+    ]
+    resp = await client.post(f"/sites/{_WIND_SITE_UUID}/generation", json=payload)
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_post_generation_unknown_uuid_returns_404(empty_client: AsyncClient) -> None:
+    """POST /sites/{uuid}/generation returns 404 for an unknown site UUID."""
+    payload = [{"PowerKW": 100.0, "Time": "2026-06-19T08:00:00Z"}]
+    resp = await empty_client.post(f"/sites/{_UNKNOWN_UUID}/generation", json=payload)
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PUT /sites/{uuid} — update site info
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_put_site_valid_uuid_returns_200(client: AsyncClient) -> None:
+    """PUT /sites/{uuid} returns 200 for a known site UUID."""
+    payload = {
+        "latitude": 23.25,
+        "longitude": 69.25,
+        "capacity_kW": 300_000,
+        "client_site_name": "ad_seci_5_updated",
+        "metadata": {},
+    }
+    resp = await client.put(f"/sites/{_WIND_SITE_UUID}", json=payload)
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_put_site_unknown_uuid_returns_404(empty_client: AsyncClient) -> None:
+    """PUT /sites/{uuid} returns 404 for an unknown site UUID."""
+    payload = {
+        "latitude": 0.0,
+        "longitude": 0.0,
+        "capacity_kW": 1000,
+        "client_site_name": "ghost_site",
+        "metadata": {},
+    }
+    resp = await empty_client.put(f"/sites/{_UNKNOWN_UUID}", json=payload)
+    assert resp.status_code == 404

--- a/src/quartz_api/internal/service/sites/test_router.py
+++ b/src/quartz_api/internal/service/sites/test_router.py
@@ -8,7 +8,6 @@ Tests cover:
 - GET /sites/{invalid}/generation — returns 404 for an unknown site UUID
 - POST /sites/{uuid}/generation   — persists generation data, returns 200
 - PUT  /sites/{uuid}              — updates site properties, returns 200
-- _resolve_observer_name          — unit tests for the observer resolution helper
 """
 
 # ruff: noqa: ARG002
@@ -26,7 +25,7 @@ from quartz_api.internal import models
 from quartz_api.internal.backends.dummydb.client import StorageClient
 from quartz_api.internal.middleware.auth import AuthDependency
 
-from .router import _resolve_observer_name, router
+from .router import router
 
 _auth_dep = typing.get_args(AuthDependency)[1].dependency
 
@@ -71,7 +70,7 @@ class SitesStorageClient(StorageClient):
                 ),
                 models.Location(
                     uuid=_SOLAR_SITE_UUID,
-                    name="ind_rajasthan_test_farm",
+                    name="dummy_solar_farm",
                     latitude=26.0,
                     longitude=76.0,
                     capacity_kilowatts=5_000,
@@ -186,7 +185,7 @@ async def test_get_sites_returns_both_solar_and_wind(client: AsyncClient) -> Non
     assert len(sites) == 2
     names = {s["client_site_name"] for s in sites}
     assert "ad_seci_5" in names
-    assert "ind_rajasthan_test_farm" in names
+    assert "dummy_solar_farm" in names
 
 
 @pytest.mark.anyio
@@ -374,52 +373,3 @@ async def test_put_site_unknown_uuid_returns_404(empty_client: AsyncClient) -> N
     }
     resp = await empty_client.put(f"/sites/{_UNKNOWN_UUID}", json=payload)
     assert resp.status_code == 404
-
-
-# ---------------------------------------------------------------------------
-# _resolve_observer_name — unit tests
-# ---------------------------------------------------------------------------
-
-
-def _make_site(name: str, energy_type: models.EnergyType) -> models.Location:
-    """Build a minimal Location for observer-resolution tests."""
-    return models.Location(
-        uuid=uuid4(),
-        name=name,
-        latitude=0.0,
-        longitude=0.0,
-        capacity_kilowatts=100.0,
-        energy_type=energy_type,
-    )
-
-
-def test_resolve_observer_ind_solar() -> None:
-    """ind_-prefixed solar site resolves to 'ind_rajasthan'."""
-    site = _make_site("ind_rajasthan_farm_1", models.EnergyType.SOLAR)
-    assert _resolve_observer_name(site, models.EnergyType.SOLAR) == "ind_rajasthan"
-
-
-def test_resolve_observer_ind_wind() -> None:
-    """ind_-prefixed wind site resolves to 'ind_rajasthan'."""
-    site = _make_site("ind_rajasthan_wind_park", models.EnergyType.WIND)
-    assert _resolve_observer_name(site, models.EnergyType.WIND) == "ind_rajasthan"
-
-
-def test_resolve_observer_adani_prefix() -> None:
-    """ad_-prefixed site (Adani) resolves to India observer 'ind_rajasthan'."""
-    site = _make_site("ad_seci_5", models.EnergyType.WIND)
-    assert _resolve_observer_name(site, models.EnergyType.WIND) == "ind_rajasthan"
-
-
-def test_resolve_observer_unknown_prefix_uses_fallback() -> None:
-    """A site with an unrecognised prefix falls back to the default."""
-    site = _make_site("gb_national", models.EnergyType.SOLAR)
-    result = _resolve_observer_name(site, models.EnergyType.SOLAR, fallback="fallback_observer")
-    assert result == "fallback_observer"
-
-
-def test_resolve_observer_default_fallback_value() -> None:
-    """The built-in fallback is 'ind_rajasthan' when no explicit fallback is given."""
-    site = _make_site("unknown_xyz", models.EnergyType.SOLAR)
-    assert _resolve_observer_name(site, models.EnergyType.SOLAR) == "ind_rajasthan"
-

--- a/src/quartz_api/internal/service/sites/test_router.py
+++ b/src/quartz_api/internal/service/sites/test_router.py
@@ -8,6 +8,7 @@ Tests cover:
 - GET /sites/{invalid}/generation — returns 404 for an unknown site UUID
 - POST /sites/{uuid}/generation   — persists generation data, returns 200
 - PUT  /sites/{uuid}              — updates site properties, returns 200
+- _resolve_observer_name          — unit tests for the observer resolution helper
 """
 
 # ruff: noqa: ARG002
@@ -25,7 +26,7 @@ from quartz_api.internal import models
 from quartz_api.internal.backends.dummydb.client import StorageClient
 from quartz_api.internal.middleware.auth import AuthDependency
 
-from .router import router
+from .router import _resolve_observer_name, router
 
 _auth_dep = typing.get_args(AuthDependency)[1].dependency
 
@@ -70,7 +71,7 @@ class SitesStorageClient(StorageClient):
                 ),
                 models.Location(
                     uuid=_SOLAR_SITE_UUID,
-                    name="dummy_solar_farm",
+                    name="ind_rajasthan_test_farm",
                     latitude=26.0,
                     longitude=76.0,
                     capacity_kilowatts=5_000,
@@ -185,7 +186,7 @@ async def test_get_sites_returns_both_solar_and_wind(client: AsyncClient) -> Non
     assert len(sites) == 2
     names = {s["client_site_name"] for s in sites}
     assert "ad_seci_5" in names
-    assert "dummy_solar_farm" in names
+    assert "ind_rajasthan_test_farm" in names
 
 
 @pytest.mark.anyio
@@ -373,3 +374,52 @@ async def test_put_site_unknown_uuid_returns_404(empty_client: AsyncClient) -> N
     }
     resp = await empty_client.put(f"/sites/{_UNKNOWN_UUID}", json=payload)
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# _resolve_observer_name — unit tests
+# ---------------------------------------------------------------------------
+
+
+def _make_site(name: str, energy_type: models.EnergyType) -> models.Location:
+    """Build a minimal Location for observer-resolution tests."""
+    return models.Location(
+        uuid=uuid4(),
+        name=name,
+        latitude=0.0,
+        longitude=0.0,
+        capacity_kilowatts=100.0,
+        energy_type=energy_type,
+    )
+
+
+def test_resolve_observer_ind_solar() -> None:
+    """ind_-prefixed solar site resolves to 'ind_rajasthan'."""
+    site = _make_site("ind_rajasthan_farm_1", models.EnergyType.SOLAR)
+    assert _resolve_observer_name(site, models.EnergyType.SOLAR) == "ind_rajasthan"
+
+
+def test_resolve_observer_ind_wind() -> None:
+    """ind_-prefixed wind site resolves to 'ind_rajasthan'."""
+    site = _make_site("ind_rajasthan_wind_park", models.EnergyType.WIND)
+    assert _resolve_observer_name(site, models.EnergyType.WIND) == "ind_rajasthan"
+
+
+def test_resolve_observer_adani_prefix() -> None:
+    """ad_-prefixed site (Adani) resolves to India observer 'ind_rajasthan'."""
+    site = _make_site("ad_seci_5", models.EnergyType.WIND)
+    assert _resolve_observer_name(site, models.EnergyType.WIND) == "ind_rajasthan"
+
+
+def test_resolve_observer_unknown_prefix_uses_fallback() -> None:
+    """A site with an unrecognised prefix falls back to the default."""
+    site = _make_site("gb_national", models.EnergyType.SOLAR)
+    result = _resolve_observer_name(site, models.EnergyType.SOLAR, fallback="fallback_observer")
+    assert result == "fallback_observer"
+
+
+def test_resolve_observer_default_fallback_value() -> None:
+    """The built-in fallback is 'ind_rajasthan' when no explicit fallback is given."""
+    site = _make_site("unknown_xyz", models.EnergyType.SOLAR)
+    assert _resolve_observer_name(site, models.EnergyType.SOLAR) == "ind_rajasthan"
+

--- a/src/quartz_api/internal/service/v1/country_config.py
+++ b/src/quartz_api/internal/service/v1/country_config.py
@@ -345,27 +345,6 @@ COUNTRIES: dict[str, CountryConfig] = {
             ),
         ),
     ),
-    "IN": CountryConfig(
-        code="IN",
-        nation_name="ind_national",  # internal DP name — not used by sites router yet
-        display_name="India",
-        permission="read:india",
-        region_types=(),  # no V1 region routes for India yet
-        generation_sources=(
-            GenerationSource(
-                source="solar",
-                name="ind_rajasthan",
-                label="India Rajasthan Solar",
-            ),
-            GenerationSource(
-                source="wind",
-                name="ind_rajasthan",
-                label="India Rajasthan Wind",
-            ),
-        ),
-    ),
 }
 
 VALID_COUNTRY_CODES: set[str] = set(COUNTRIES.keys())
-
-

--- a/src/quartz_api/internal/service/v1/country_config.py
+++ b/src/quartz_api/internal/service/v1/country_config.py
@@ -345,6 +345,27 @@ COUNTRIES: dict[str, CountryConfig] = {
             ),
         ),
     ),
+    "IN": CountryConfig(
+        code="IN",
+        nation_name="ind_national",  # internal DP name — not used by sites router yet
+        display_name="India",
+        permission="read:india",
+        region_types=(),  # no V1 region routes for India yet
+        generation_sources=(
+            GenerationSource(
+                source="solar",
+                name="ind_rajasthan",
+                label="India Rajasthan Solar",
+            ),
+            GenerationSource(
+                source="wind",
+                name="ind_rajasthan",
+                label="India Rajasthan Wind",
+            ),
+        ),
+    ),
 }
 
 VALID_COUNTRY_CODES: set[str] = set(COUNTRIES.keys())
+
+


### PR DESCRIPTION
# Pull Request
## Description
This PR upgrades the Data Platform SDK to `v0.32.0` and completes the migration from user-level filtering (`user_oauth_id_filter`) to organization-level access control (`organisation_id_filter`) based on HubSpot company 
IDs. 

[Issue](https://github.com/openclimatefix/client-private/issues/482)
### Key Changes
* **Dependency Updates (`pyproject.toml`)**:
  * Upgraded `dp-sdk` to version `v0.32.0`.
* **Auth Helper (`auth.py`)**:
  * Centralized extraction logic in `get_org_id_from_authdata` to retrieve the `hubspot_company_id` from the JWT `app_metadata` dictionary.
* **Storage Client Interface (`db_interface.py`, `client.py`, `dummydb/client.py`)**:
  * Updated `get_locations` to allow `energy_type` to be optional (`None`), enabling retrieval of both solar and wind sites in a single query.
  * Restored match block scoping in `client.py`'s `get_locations` and `get_predicted_generation`. Public queries (e.g. Regions, Nations, GSPs) bypass organization filtering (`organisation_id = None`), while private site/substation queries resolve the correct HubSpot company ID filter.
* **Sites Router (`router.py`)**:
  * Extracted helper `_get_site_with_energy_type` to auto-detect a site's energy type (solar or wind) rather than hardcoding solar, and updated site-specific forecast and generation routes to use it.
* **Unit Tests (`test_client.py`, `test_router.py`)**:
  * Restored and updated access-control tests in `test_client.py` for substations and sites to expect empty lists or HTTPExceptions when requested without valid organization access.
  * Added a complete mock router test suite for all routes under `/sites` in `test_router.py` (covering valid site UUIDs, invalid site UUIDs, and empty organisation payloads).
---
## How Has This Been Tested?
### 1. Automated Tests
Ran the internal test suite:
```bash
uv run pytest src/quartz_api/internal/ 
```
All **191 tests passed successfully**.
### 2. Manual Verification
Ran the server locally (`source .env.local && uv run quartz-api`):
* **GET `/sites`**: Hitting `/sites` with a valid Auth0 token containing `hubspot_company_id: "99999999999"` returned the correct sites.
* **GET `/sites/{site_uuid}/forecast` (Valid UUID)**: Requesting an owned site forecast succeeded with `200 OK` and returned forecast values.
* **GET `/sites/{site_uuid}/forecast` (Invalid UUID)**: Succeeded in raising `404 Not Found` with the correct detail message: `"No site found for UUID '<uuid>'."`
- [x] Yes
## Checklist:
- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
