### PR TITLE
Install rasterio runtime dependencies in container image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -38,6 +38,7 @@ RUN rm -rf /opt/app/.venv/lib/python3.12/site-packages/**/test_*
 # --- Runtime image (use distroless if feasible for 100MB saving) --- #
 FROM python:3.12-slim-bookworm AS runtime
 
+# Add runtime dependencies for rasterio
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libexpat1 \
     libgdal32 \

--- a/Containerfile
+++ b/Containerfile
@@ -38,6 +38,11 @@ RUN rm -rf /opt/app/.venv/lib/python3.12/site-packages/**/test_*
 # --- Runtime image (use distroless if feasible for 100MB saving) --- #
 FROM python:3.12-slim-bookworm AS runtime
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libexpat1 \
+    libgdal32 \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /opt/app
 # Copy just the virtual environment into a runtime image
 COPY --from=build-app /opt/app/.venv /opt/app/.venv


### PR DESCRIPTION
# Pull Request

## Description

Rasterio and its native dependencies were installed during the build stage, but the required shared libraries were not available in the final runtime image. This resulted in the following error during application startup:
`ImportError: libexpat.so.1: cannot open shared object file: No such file or directory`

## How Has This Been Tested?

- [x] Locally 

<img width="1121" height="177" alt="image" src="https://github.com/user-attachments/assets/e307ea22-fde6-4f6c-94c2-2ff9a5e24f9d" />

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
