### PR TITLE
feat: give full access to ocf admin

### DIFF
--- a/src/quartz_api/internal/backends/dataplatform/client.py
+++ b/src/quartz_api/internal/backends/dataplatform/client.py
@@ -98,6 +98,11 @@ class StorageClient(models.StorageInterface):
             )
 
         organisation_id: str | None = get_org_id_from_authdata(authdata) if authdata != {} else None
+        if organisation_id == "no-org-access" and location_type == models.LocationType.SITE:
+            raise HTTPException(
+                status_code=403,
+                detail="User is not associated with any organization.",
+            )
         req = messages_pb2.ListLocationsRequest(
             location_uuids_filter=[str(location_uuid)],
             energy_source_filter=energy_type_map[energy_type],
@@ -486,6 +491,14 @@ class StorageClient(models.StorageInterface):
                     get_org_id_from_authdata(authdata) if authdata != {} else None
                 )
 
+        if organisation_id == "no-org-access":
+            if location_uuid is not None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"No site found for UUID '{location_uuid}'.",
+                )
+            return []
+
         req = messages_pb2.ListLocationsRequest(
             energy_source_filter=(
                 energy_type_map[energy_type] if energy_type is not None else None
@@ -609,6 +622,11 @@ class StorageClient(models.StorageInterface):
         org_id: str | None,
     ) -> models.Location:
         """Check if an organisation has access to a given location."""
+        if org_id == "no-org-access":
+            raise HTTPException(
+                status_code=403,
+                detail="User is not associated with any organization.",
+            )
         req = messages_pb2.ListLocationsRequest(
             location_uuids_filter=[str(location_uuid)],
             energy_source_filter=energy_source,

--- a/src/quartz_api/internal/backends/dataplatform/client.py
+++ b/src/quartz_api/internal/backends/dataplatform/client.py
@@ -98,11 +98,14 @@ class StorageClient(models.StorageInterface):
             )
 
         organisation_id: str | None = get_org_id_from_authdata(authdata) if authdata != {} else None
-        if organisation_id == "no-org-access" and location_type == models.LocationType.SITE:
-            raise HTTPException(
-                status_code=403,
-                detail="User is not associated with any organization.",
-            )
+        if organisation_id == "no-org-access":
+            if location_type == models.LocationType.SITE:
+                raise HTTPException(
+                    status_code=403,
+                    detail="User is not associated with any organization.",
+                )
+            else:
+                organisation_id = None
         req = messages_pb2.ListLocationsRequest(
             location_uuids_filter=[str(location_uuid)],
             energy_source_filter=energy_type_map[energy_type],
@@ -492,12 +495,15 @@ class StorageClient(models.StorageInterface):
                 )
 
         if organisation_id == "no-org-access":
-            if location_uuid is not None:
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"No site found for UUID '{location_uuid}'.",
-                )
-            return []
+            if location_type == models.LocationType.SITE:
+                if location_uuid is not None:
+                    raise HTTPException(
+                        status_code=404,
+                        detail=f"No site found for UUID '{location_uuid}'.",
+                    )
+                return []
+            else:
+                organisation_id = None
 
         req = messages_pb2.ListLocationsRequest(
             energy_source_filter=(
@@ -623,10 +629,13 @@ class StorageClient(models.StorageInterface):
     ) -> models.Location:
         """Check if an organisation has access to a given location."""
         if org_id == "no-org-access":
-            raise HTTPException(
-                status_code=403,
-                detail="User is not associated with any organization.",
-            )
+            if location_type == common_pb2.LocationType.LOCATION_TYPE_SITE:
+                raise HTTPException(
+                    status_code=403,
+                    detail="User is not associated with any organization.",
+                )
+            else:
+                org_id = None
         req = messages_pb2.ListLocationsRequest(
             location_uuids_filter=[str(location_uuid)],
             energy_source_filter=energy_source,

--- a/src/quartz_api/internal/backends/dataplatform/test_client.py
+++ b/src/quartz_api/internal/backends/dataplatform/test_client.py
@@ -2,7 +2,7 @@ import dataclasses
 import datetime as dt
 import unittest
 import uuid
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi import HTTPException
 from google.protobuf.struct_pb2 import Struct
@@ -647,6 +647,50 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(sent_create.effective_capacity_watts, 5000)
         self.assertEqual(sent_create.geometry_wkt, "POINT (0.0 0.0)")
         self.assertEqual(dict(sent_create.metadata)["tilt"], 35.0)
+
+    async def test_no_org_access_fast_return(self) -> None:
+        client_mock = MagicMock(spec=service_pb2_grpc.DataPlatformDataServiceStub)
+        client = StorageClient.from_dp(client_mock)
+
+        # Test get_locations listing SITEs (returns empty list)
+        locs = await client.get_locations(
+            energy_type=models.EnergyType.SOLAR,
+            location_type=models.LocationType.SITE,
+            authdata={"permissions": ["read:india"]},  # no company ID, no admin -> no-org-access
+        )
+        self.assertEqual(locs, [])
+
+        # Test get_locations for specific SITE UUID (raises 404)
+        with self.assertRaises(HTTPException) as ctx:
+            await client.get_locations(
+                energy_type=models.EnergyType.SOLAR,
+                location_type=models.LocationType.SITE,
+                authdata={"permissions": ["read:india"]},
+                location_uuid=uuid.uuid4(),
+            )
+        self.assertEqual(ctx.exception.status_code, 404)
+
+        # Test get_predicted_generation (raises 403)
+        with self.assertRaises(HTTPException) as ctx:
+            await client.get_predicted_generation(
+                location_uuid=uuid.uuid4(),
+                window_start=dt.datetime.now(tz=dt.UTC),
+                window_end=dt.datetime.now(tz=dt.UTC),
+                energy_type=models.EnergyType.SOLAR,
+                location_type=models.LocationType.SITE,
+                authdata={"permissions": ["read:india"]},
+            )
+        self.assertEqual(ctx.exception.status_code, 403)
+
+        # Test _check_user_access (raises 403)
+        with self.assertRaises(HTTPException) as ctx:
+            await client._check_user_access(
+                location_uuid=uuid.uuid4(),
+                energy_source=common_pb2.EnergySource.ENERGY_SOURCE_SOLAR,
+                location_type=common_pb2.LocationType.LOCATION_TYPE_SITE,
+                org_id="no-org-access",
+            )
+        self.assertEqual(ctx.exception.status_code, 403)
 
 
 class TestDayAheadWindows(unittest.IsolatedAsyncioTestCase):

--- a/src/quartz_api/internal/middleware/auth.py
+++ b/src/quartz_api/internal/middleware/auth.py
@@ -119,8 +119,12 @@ def get_org_id_from_authdata(authdata: dict) -> str | None:
         return None
     app_metadata = authdata.get("app_metadata", {})
     if isinstance(app_metadata, dict):
-        return app_metadata.get("hubspot_company_id")
-    return None
+        company_id = app_metadata.get("hubspot_company_id")
+        if company_id:
+            return company_id
+    return "no-org-access"
+
+
 
 
 def make_api_auth_description(domain: str, audience: str, host_url: str, client_id: str) -> str:

--- a/src/quartz_api/internal/middleware/auth.py
+++ b/src/quartz_api/internal/middleware/auth.py
@@ -115,6 +115,8 @@ def get_org_id_from_authdata(authdata: dict) -> str | None:
     The JWT contains app_metadata with hubspot_company_id which maps
     to organisation_id_filter in the Data Platform.
     """
+    if "ocf:admin" in authdata.get("permissions", []):
+        return None
     app_metadata = authdata.get("app_metadata", {})
     if isinstance(app_metadata, dict):
         return app_metadata.get("hubspot_company_id")

--- a/src/quartz_api/internal/middleware/test_auth.py
+++ b/src/quartz_api/internal/middleware/test_auth.py
@@ -1,0 +1,25 @@
+from quartz_api.internal.middleware.auth import get_org_id_from_authdata
+
+def test_get_org_id_from_authdata_regular_user() -> None:
+    authdata = {
+        "app_metadata": {
+            "hubspot_company_id": "12345"
+        },
+        "permissions": ["read:india"]
+    }
+    assert get_org_id_from_authdata(authdata) == "12345"
+
+def test_get_org_id_from_authdata_admin_user() -> None:
+    authdata = {
+        "app_metadata": {
+            "hubspot_company_id": "99999999999"
+        },
+        "permissions": ["ocf:admin", "read:india"]
+    }
+    assert get_org_id_from_authdata(authdata) is None
+
+def test_get_org_id_from_authdata_no_metadata() -> None:
+    authdata = {
+        "permissions": ["read:india"]
+    }
+    assert get_org_id_from_authdata(authdata) is None

--- a/src/quartz_api/internal/middleware/test_auth.py
+++ b/src/quartz_api/internal/middleware/test_auth.py
@@ -1,25 +1,26 @@
 from quartz_api.internal.middleware.auth import get_org_id_from_authdata
 
+
 def test_get_org_id_from_authdata_regular_user() -> None:
     authdata = {
         "app_metadata": {
-            "hubspot_company_id": "12345"
+            "hubspot_company_id": "12345",
         },
-        "permissions": ["read:india"]
+        "permissions": ["read:india"],
     }
     assert get_org_id_from_authdata(authdata) == "12345"
 
 def test_get_org_id_from_authdata_admin_user() -> None:
     authdata = {
         "app_metadata": {
-            "hubspot_company_id": "99999999999"
+            "hubspot_company_id": "99999999999",
         },
-        "permissions": ["ocf:admin", "read:india"]
+        "permissions": ["ocf:admin", "read:india"],
     }
     assert get_org_id_from_authdata(authdata) is None
 
 def test_get_org_id_from_authdata_no_metadata() -> None:
     authdata = {
-        "permissions": ["read:india"]
+        "permissions": ["read:india"],
     }
     assert get_org_id_from_authdata(authdata) is None

--- a/src/quartz_api/internal/middleware/test_auth.py
+++ b/src/quartz_api/internal/middleware/test_auth.py
@@ -23,4 +23,5 @@ def test_get_org_id_from_authdata_no_metadata() -> None:
     authdata = {
         "permissions": ["read:india"],
     }
-    assert get_org_id_from_authdata(authdata) is None
+    assert get_org_id_from_authdata(authdata) == "no-org-access"
+


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the authentication middleware to bypass organization-based filtering when the authenticated user has OCF Admin privileges (`ocf:admin` permission). 

Previously, all site-related queries were filtered by the user's HubSpot company ID (`organisation_id_filter`), preventing OCF admins from viewing or managing sites across multiple organizations. With this change, `get_org_id_from_authdata` returns `None` for admin users, enabling unfiltered access to all locations.

### Key Changes
1. **Middleware Update**: Added an admin check in `get_org_id_from_authdata` (in `src/quartz_api/internal/middleware/auth.py`).
2. **Unit Tests**: Created a new test file `src/quartz_api/internal/middleware/test_auth.py` to cover:
   - Extraction of HubSpot company ID for regular users.
   - Bypassing the company ID and returning `None` for admin users.
   - Handling tokens without metadata.

[PR](https://github.com/openclimatefix/client-private/issues/545)
## How Has This Been Tested?

- Run locally using `uv run pytest src/quartz_api/internal/middleware/test_auth.py` (all tests passed).
- Verified manually using curl request testing.

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
