### PR TITLE
fix: properly apply rate limiting for v1 routes

### DIFF
--- a/src/quartz_api/cmd/main.py
+++ b/src/quartz_api/cmd/main.py
@@ -171,6 +171,8 @@ def _create_v1_app(
     )
 
     v1_app.state.limiter = ratelimit.limiter
+    v1_app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    v1_app.add_middleware(SlowAPIMiddleware)
     v1_app.include_router(v1_mod.router)
     v1_app.openapi = lambda: _custom_openapi(v1_app, auth_openapi_config)
 

--- a/src/quartz_api/cmd/main.py
+++ b/src/quartz_api/cmd/main.py
@@ -24,7 +24,7 @@ from fastapi_cache.backends.inmemory import InMemoryBackend
 from pydantic import BaseModel
 from pyhocon import ConfigFactory, ConfigTree
 from scalar_fastapi import AgentScalarConfig, Theme, get_scalar_api_reference
-from slowapi import _rate_limit_exceeded_handler
+from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from starlette.middleware.gzip import GZipMiddleware
@@ -148,6 +148,7 @@ def _custom_openapi(
 def _create_v1_app(
     conf: ConfigTree,
     auth_openapi_config: dict[str, str] | None,
+    limiter: Limiter | None = None,
 ) -> FastAPI:
     """Create and configure the v1 FastAPI sub-application."""
     v1_mod = importlib.import_module(service.__name__ + ".v1")
@@ -170,7 +171,7 @@ def _create_v1_app(
         redoc_url=None,
     )
 
-    v1_app.state.limiter = ratelimit.limiter
+    v1_app.state.limiter = limiter or ratelimit.limiter
     v1_app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
     v1_app.add_middleware(SlowAPIMiddleware)
     v1_app.include_router(v1_mod.router)

--- a/src/quartz_api/internal/middleware/test_ratelimit.py
+++ b/src/quartz_api/internal/middleware/test_ratelimit.py
@@ -1,10 +1,15 @@
 """Tests for rate limiting utilities."""
+import typing
+
 import jwt
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
+from pyhocon import ConfigFactory
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 
+from quartz_api.cmd.main import _create_v1_app
+from quartz_api.internal.middleware.auth import AuthDependency
 from quartz_api.internal.middleware.ratelimit import get_user_key
 
 
@@ -90,4 +95,37 @@ def test_get_user_key_falls_back_to_ip_on_invalid_jwt() -> None:
     response = client.get("/key", headers={"Authorization": "Bearer not.a.real.jwt"})
     assert response.status_code == 200
     assert response.json()["key"] == "testclient"
+
+
+def test_v1_app_rate_limiting() -> None:
+    """Test that rate limiting is applied to v1 sub-app routes.
+
+    Uses a local Limiter instance (1/second) to avoid mutating the global
+    singleton and keep the test fully isolated.
+    """
+    conf = ConfigFactory.parse_string('auth0 { client_id = "test_client" }')
+    v1_app = _create_v1_app(conf, None)
+
+    # Override the auth dependency so it bypasses auth signature verification
+    auth_dep = typing.get_args(AuthDependency)[1].dependency
+    v1_app.dependency_overrides[auth_dep] = lambda: {"sub": "test_user_rate_limit"}
+
+    # Replace the app-level limiter with a local restrictive one (1/second)
+    # so we don't mutate the shared global singleton or rely on LimitGroup internals.
+    local_limiter = Limiter(
+        key_func=get_user_key,
+        default_limits=["1/second"],
+        key_style="endpoint",
+    )
+    v1_app.state.limiter = local_limiter
+
+    client = TestClient(v1_app, raise_server_exceptions=False)
+
+    # First request should succeed
+    r1 = client.get("/sources")
+    assert r1.status_code == 200
+
+    # Second request within the same second should trigger 429
+    r2 = client.get("/sources")
+    assert r2.status_code == 429
 

--- a/src/quartz_api/internal/middleware/test_ratelimit.py
+++ b/src/quartz_api/internal/middleware/test_ratelimit.py
@@ -103,21 +103,20 @@ def test_v1_app_rate_limiting() -> None:
     Uses a local Limiter instance (1/second) to avoid mutating the global
     singleton and keep the test fully isolated.
     """
-    conf = ConfigFactory.parse_string('auth0 { client_id = "test_client" }')
-    v1_app = _create_v1_app(conf, None)
-
-    # Override the auth dependency so it bypasses auth signature verification
-    auth_dep = typing.get_args(AuthDependency)[1].dependency
-    v1_app.dependency_overrides[auth_dep] = lambda: {"sub": "test_user_rate_limit"}
-
-    # Replace the app-level limiter with a local restrictive one (1/second)
-    # so we don't mutate the shared global singleton or rely on LimitGroup internals.
+    # Create a local restrictive limiter (1/second) so we don't mutate
+    # the shared global singleton or rely on LimitGroup internals.
     local_limiter = Limiter(
         key_func=get_user_key,
         default_limits=["1/second"],
         key_style="endpoint",
     )
-    v1_app.state.limiter = local_limiter
+
+    conf = ConfigFactory.parse_string('auth0 { client_id = "test_client" }')
+    v1_app = _create_v1_app(conf, None, limiter=local_limiter)
+
+    # Override the auth dependency so it bypasses auth signature verification
+    auth_dep = typing.get_args(AuthDependency)[1].dependency
+    v1_app.dependency_overrides[auth_dep] = lambda: {"sub": "test_user_rate_limit"}
 
     client = TestClient(v1_app, raise_server_exceptions=False)
 


### PR DESCRIPTION
# Pull Request

## Description

This PR resolves a gap where mounted sub-application routes were bypassing rate limit rules.

### Enable Rate Limiting for the mounted `/v1` Sub-App
FastAPI sub-applications mounted via `app.mount()` run as isolated ASGI applications. Because of this, the parent application's `SlowAPIMiddleware` was resolving `/v1` routes to the generic `Mount` handler (which has no `endpoint` function reference), causing `slowapi` to skip rate-limit checks entirely.

**Investigation — how we found the gap:**
I started by checking whether rate limiting was already in place for `v1` routes. The `SlowAPIMiddleware` and `ratelimit.limiter` were registered on the parent app, and `v1_app.state.limiter` was already being set — so it looked correct at first glance.

To confirm, I ran 25 rapid requests against the local server with the `v1` router enabled:
```bash
for i in {1..25}; do
  curl -s -o /dev/null -w "Request $i: HTTP %{http_code}\n" \
       -H "Authorization: Bearer <TOKEN>" \
       http://localhost:8000/v1/sources
done
```

*Before the fix:* All 25 returned `200 OK`, and no `429` was triggered.

**Root cause:**
The `v1` app is mounted as a sub-application inside the parent FastAPI app via `app.mount("/v1", v1_app)`. When a request for `/v1/sources` arrives at the parent app, `SlowAPIMiddleware` looks up the route and finds a `Mount` object (not an endpoint function). Since `slowapi` uses the endpoint function name as the rate limit key, it resolves to an empty string and silently skips rate enforcement. The parent's middleware never reaches into the sub-app's routes.

**Fix:**
Registered `SlowAPIMiddleware` and the `RateLimitExceeded` exception handler directly onto the `v1_app` instance inside `_create_v1_app` in `src/quartz_api/cmd/main.py`. This correctly subjects all `/v1` endpoints to the default limits (20 requests/second, 3600/hour).

*After the fix:* The same curl loop correctly returns `429 Too Many Requests` starting at the 21st call, and server logs display:
```
WARNING slowapi: ratelimit 20 per 1 second (google-oauth2|...) exceeded at endpoint: quartz_api.internal.service.v1.routes.discovery.get_sources
```

No new dependencies are required for this change.

## How Has This Been Tested?

### Unit Tests
1. **Middleware Isolation Tests:** Added `test_v1_app_rate_limiting` to `test_ratelimit.py` to assert that sub-app routes properly return `429 Too Many Requests` when limits are exceeded.
2. **Run Test Suite:**
   ```bash
   uv run pytest src/quartz_api/internal/middleware/test_ratelimit.py -v
   ```
   *Result:* All tests pass.

### Manual Verification
1. Started the local server with sub-app routers active:
   ```bash
   source .env.local && export ROUTERS=sites,regions,v1 && uv run quartz-api
   ```
2. Tested the standard sub-app rate limits (20/second threshold):
   ```bash
   for i in {1..25}; do
     curl -s -o /dev/null -w "Request $i: HTTP %{http_code}\n" \
          -H "Authorization: Bearer <TOKEN>" \
          http://localhost:8000/v1/sources
   done
   # Requests 1-20 returned 200, 21-25 returned 429
   ```

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
