### PR TITLE
feat: blackout and latest flag sat get api

### DIFF
--- a/src/quartz_api/internal/s3.py
+++ b/src/quartz_api/internal/s3.py
@@ -1,4 +1,6 @@
 """S3 client."""
+from datetime import UTC, datetime, timedelta
+
 import fsspec
 
 # Satellite S3 config, populated at startup via configure() from the parsed
@@ -81,6 +83,19 @@ class S3Client:
     def object_exists(self, bucket: str, key: str) -> bool:
         """Check if an object exists in S3."""
         return self.fs.exists(f"s3://{bucket}/{key}")
+
+    def get_latest_key(
+        self, bucket: str, prefix: str, lookback_minutes: int = 30,
+    ) -> str | None:
+        """Probe 5-min-cadence keys backward from now, return the first one that exists."""
+        ts = datetime.now(tz=UTC).replace(second=0, microsecond=0)
+        ts -= timedelta(minutes=ts.minute % 5)
+        for _ in range(lookback_minutes // 5 + 1):
+            key = f"{prefix}{ts:%Y%m%d_%H%M%S}.tif"
+            if self.object_exists(bucket, key):
+                return key
+            ts -= timedelta(minutes=5)
+        return None
 
     def upload_bytes(self, bucket: str, key: str, data: bytes) -> None:
         """Upload raw bytes to an S3 key."""

--- a/src/quartz_api/internal/s3.py
+++ b/src/quartz_api/internal/s3.py
@@ -87,7 +87,11 @@ class S3Client:
     def get_latest_key(
         self, bucket: str, prefix: str, lookback_minutes: int = 30,
     ) -> str | None:
-        """Probe 5-min-cadence keys backward from now, return the first one that exists."""
+        """Search backwards in 5-minute intervals and return the first available key.
+
+        Used to show the LIVE cloud image in the UI. The default 30-minute lookback
+        keeps the image recent while remaining visually distinct.
+        """
         ts = datetime.now(tz=UTC).replace(second=0, microsecond=0)
         ts -= timedelta(minutes=ts.minute % 5)
         for _ in range(lookback_minutes // 5 + 1):

--- a/src/quartz_api/internal/service/satellite/_ingest.py
+++ b/src/quartz_api/internal/service/satellite/_ingest.py
@@ -123,14 +123,6 @@ def _run_ingest(sat_type: str) -> tuple[str, str]:
         "EPSG:4326", "EPSG:3857", LEFT, BOTTOM, RIGHT, TOP,
     )
     wgs84_bounds_tag = f"{LEFT},{BOTTOM},{RIGHT},{TOP}"
-    geos_left, geos_bottom, geos_right, geos_top = transform_bounds(
-        "EPSG:4326", src_crs, LEFT, BOTTOM, RIGHT, TOP,
-    )
-    inv_tf = ~src_tf
-    col_min, row_max = inv_tf * (geos_left, geos_bottom)
-    col_max, row_min = inv_tf * (geos_right, geos_top)
-    r0, r1 = max(0, int(row_min)), min(len(y), int(row_max))
-    c0, c1 = max(0, int(col_min)), min(len(x), int(col_max))
 
     # Filter to last 48 hours
     cutoff = np.datetime64("now") - np.timedelta64(BACKFILL_HOURS, "h")
@@ -162,19 +154,7 @@ def _run_ingest(sat_type: str) -> tuple[str, str]:
                     arr = ds["data"].isel(time=t_idx, channel=chan_idx).values.astype(np.float32)
                     arr = np.flipud(arr)
 
-                    if "percentile" in config:
-                        uk_subwindow = arr[r0:r1, c0:c1]
-                        valid_local = uk_subwindow[~np.isnan(uk_subwindow)]
-
-                        if len(valid_local) > 0:
-                            p_val = float(np.percentile(valid_local, config["percentile"]))
-
-                            # Above cliff_limit, daylight is active -> drop threshold to 0.0
-                            applied_threshold = 0.0 if p_val > config["cliff_limit"] else p_val
-
-                            if applied_threshold > 0.0:
-                                arr = np.where(arr < applied_threshold, 0.0, arr)
-                    elif config.get("invert"):
+                    if config.get("invert"):
                         arr = 1.0 - arr
 
                     dst_arr = np.full((dst_h, dst_w), np.nan, dtype=np.float32)

--- a/src/quartz_api/internal/service/satellite/_ingest.py
+++ b/src/quartz_api/internal/service/satellite/_ingest.py
@@ -25,8 +25,7 @@ log = logging.getLogger(__name__)
 LEFT, BOTTOM, RIGHT, TOP = -17.05, 46.49, 11.60, 63.31
 # How far back to backfill missing data (in hours)
 BACKFILL_HOURS = 48
-# config to remove artifacts during nighttime, invert channels, and blackout
-# a channel at recurring daily "HH:MM" (UTC) times-of-day.
+# Per-channel nighttime cleanup, inversion, and recurring "HH:MM" (UTC) blackout times.
 LAYER_CONFIG = {
     "VIS006": {"blackout": ["23:45", "00:15", "00:45", "01:15"]},
     "VIS008": {"blackout": ["23:45", "00:15", "00:45", "01:15"]},
@@ -45,14 +44,7 @@ _ingest_running: bool = False
 
 
 def run_ingest() -> tuple[str, str]:
-    """Run ingest of latest satellite data for all channels.
-
-    Uploads any missing channel+timestamp combos from the last 4 hours,
-    skipping ones already present in S3.
-
-    Returns:
-        Tuple of (latest timestamp, ts_str).
-    """
+    """Upload missing channel+timestamp combos from the last 48h; returns (latest_t, ts_str)."""
     global _ingest_running
     if _ingest_running:
         log.info("Ingest already running, skipping")
@@ -165,11 +157,9 @@ def _run_ingest() -> tuple[str, str]:
                         if len(valid_local) > 0:
                             p_val = float(np.percentile(valid_local, config["percentile"]))
 
-                            # Cliff logic switch: if noise distribution crosses the limit,
-                            # true daylight is active -> Drop threshold to 0.0
+                            # Above cliff_limit, daylight is active -> drop threshold to 0.0
                             applied_threshold = 0.0 if p_val > config["cliff_limit"] else p_val
 
-                            # Flatten noise floor cleanly to uniform black
                             if applied_threshold > 0.0:
                                 arr = np.where(arr < applied_threshold, 0.0, arr)
                     elif config.get("invert"):

--- a/src/quartz_api/internal/service/satellite/_ingest.py
+++ b/src/quartz_api/internal/service/satellite/_ingest.py
@@ -25,11 +25,12 @@ log = logging.getLogger(__name__)
 LEFT, BOTTOM, RIGHT, TOP = -17.05, 46.49, 11.60, 63.31
 # How far back to backfill missing data (in hours)
 BACKFILL_HOURS = 48
-# config to remove artifacts during nighttime and invert channels
+# config to remove artifacts during nighttime, invert channels, and blackout
+# a channel at recurring daily "HH:MM" (UTC) times-of-day.
 LAYER_CONFIG = {
-    "VIS006": {"percentile": 99.0, "cliff_limit": 5.0},
-    "VIS008": {"percentile": 99.0, "cliff_limit": 10.0},
-    "IR_016": {"percentile": 99.0, "cliff_limit": 12.0},
+    "VIS006": {"blackout": ["23:45", "00:15", "00:45", "01:15"]},
+    "VIS008": {"blackout": ["23:45", "00:15", "00:45", "01:15"]},
+    "IR_016": {"blackout": ["23:45", "00:15", "00:45"]},
     "IR_039": {"invert": True},
     "IR_087": {"invert": True},
     "IR_097": {"invert": True},
@@ -148,12 +149,14 @@ def _run_ingest() -> tuple[str, str]:
                 continue
 
             try:
-                chan_idx = list(ds.channel.values).index(channel)
-                arr = ds["data"].isel(time=t_idx, channel=chan_idx).values.astype(np.float32)
-                arr = np.flipud(arr)
+                config = LAYER_CONFIG.get(channel, {})
 
-                if channel in LAYER_CONFIG:
-                    config = LAYER_CONFIG[channel]
+                if ts_str[9:13] in {t.replace(":", "") for t in config.get("blackout", [])}:
+                    dst_arr = np.zeros((dst_h, dst_w), dtype=np.float32)
+                else:
+                    chan_idx = list(ds.channel.values).index(channel)
+                    arr = ds["data"].isel(time=t_idx, channel=chan_idx).values.astype(np.float32)
+                    arr = np.flipud(arr)
 
                     if "percentile" in config:
                         uk_subwindow = arr[r0:r1, c0:c1]
@@ -172,14 +175,14 @@ def _run_ingest() -> tuple[str, str]:
                     elif config.get("invert"):
                         arr = 1.0 - arr
 
-                dst_arr = np.full((dst_h, dst_w), np.nan, dtype=np.float32)
-                reproject(
-                    source=arr, destination=dst_arr,
-                    src_transform=src_tf, src_crs=src_crs,
-                    dst_transform=dst_tf, dst_crs=dst_crs,
-                    resampling=Resampling.bilinear,
-                    src_nodata=np.nan, dst_nodata=np.nan,
-                )
+                    dst_arr = np.full((dst_h, dst_w), np.nan, dtype=np.float32)
+                    reproject(
+                        source=arr, destination=dst_arr,
+                        src_transform=src_tf, src_crs=src_crs,
+                        dst_transform=dst_tf, dst_crs=dst_crs,
+                        resampling=Resampling.bilinear,
+                        src_nodata=np.nan, dst_nodata=np.nan,
+                    )
 
                 full_buf = io.BytesIO()
                 with rasterio.open(

--- a/src/quartz_api/internal/service/satellite/router.py
+++ b/src/quartz_api/internal/service/satellite/router.py
@@ -42,11 +42,12 @@ S3ClientDep = Annotated[S3Client, Depends(get_s3_client)]
 def get_historic_satellite_data_url(
     request: Request,  # noqa: ARG001
     channel: str,
-    timestamp: datetime,
     s3_client: S3ClientDep,
     _: AuthDependency,
+    timestamp: datetime | None = None,
+    latest: bool = False,
 ) -> HistoricSatelliteData:
-    """Get a pre-signed URL for a historic satellite data file."""
+    """Get a pre-signed URL for a satellite file; ``latest=true`` ignores ``timestamp``."""
     if channel not in VALID_CHANNELS:
         raise HTTPException(
             status_code=400,
@@ -54,6 +55,22 @@ def get_historic_satellite_data_url(
         )
 
     bucket = get_geotiff_bucket()
+
+    if latest:
+        key = s3_client.get_latest_key(bucket, f"layers/{channel}/")
+        if key is None:
+            raise HTTPException(
+                status_code=404,
+                detail="No files found for the given channel in the last 30 minutes",
+            )
+        return HistoricSatelliteData(url=s3_client.get_presigned_url(bucket, key))
+
+    if timestamp is None:
+        raise HTTPException(
+            status_code=400,
+            detail="timestamp is required unless latest=true",
+        )
+
     key = f"layers/{channel}/{timestamp.strftime('%Y%m%d_%H%M%S')}.tif"
 
     if not s3_client.object_exists(bucket, key):


### PR DESCRIPTION
# Pull Request

## Description

Add a blackout period, as the percentile filters are not accurate enough and the image is completely black at night for certain channels.

Add the latest flag to the GET sat route, to find the latest available timestamp to show on live in FE

## How Has This Been Tested?

- [x] Locally

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
