### PR TITLE
feat: add all 7 p-levels from dp

### DIFF
--- a/src/quartz_api/internal/backends/dataplatform/client.py
+++ b/src/quartz_api/internal/backends/dataplatform/client.py
@@ -215,14 +215,10 @@ class StorageClient(models.StorageInterface):
                 -> list[models.PredictedGenerationValue]:
             out: list[models.PredictedGenerationValue] = []
             for v in values:
-                plevels: dict[str, int | float] = {}
-                stats = v.other_statistics_fractions
-                for plevel in ["p10", "p90"]:
-                    val = int(
-                        v.effective_capacity_watts * stats[plevel] / 1000.0,
-                    ) if plevel in stats else None
-                    if val is not None:
-                        plevels[plevel] = val
+                plevels: dict[str, int | float] = {
+                    f"p{int(plevel[1:])}": int(v.effective_capacity_watts * frac / 1000.0)
+                    for plevel, frac in v.other_statistics_fractions.items()
+                }
 
                 out.append(models.PredictedGenerationValue(
                     power_kilowatts=int(

--- a/src/quartz_api/internal/backends/dataplatform/test_client.py
+++ b/src/quartz_api/internal/backends/dataplatform/test_client.py
@@ -72,7 +72,14 @@ def mock_get_forecast(
                 - dt.timedelta(minutes=req.horizon_mins),
                 created_timestamp_utc=TEST_TIMESTAMP_UTC
                 - dt.timedelta(hours=1, minutes=req.horizon_mins),
-                other_statistics_fractions={"p90": 0.9, "p10": 0.1},
+                other_statistics_fractions={
+                    "p90": 0.9,
+                    "p02": 0.02,
+                    "p98": 0.98,
+                    "p10": 0.1,
+                    "p75": 0.75,
+                    "p25": 0.25,
+                },
                 metadata=Struct(fields={}),
             )
             for i in range(5)
@@ -243,6 +250,10 @@ class TestDataPlatformClient(unittest.IsolatedAsyncioTestCase):
                         energy_type=models.EnergyType.SOLAR,
                     )
                     self.assertEqual(len(resp), 5)
+                    self.assertEqual(
+                        resp[0].plevels_kilowatts,
+                        {"p90": 899, "p2": 19, "p98": 980, "p10": 100, "p75": 750, "p25": 250},
+                    )
 
     @patch("ocf.dp.dp_data.service_pb2_grpc.DataPlatformDataServiceStub")
     async def test_get_site_generation(

--- a/src/quartz_api/internal/service/uk_national/national_router.py
+++ b/src/quartz_api/internal/service/uk_national/national_router.py
@@ -192,12 +192,11 @@ async def get_national_forecast(
             target_time=v.valid_timestamp,
             expected_power_generation_megawatts=v.power_kilowatts / 1000,
             plevels={
-                "plevel_10": v.plevels_kilowatts.get("p10") / 1000
-                if v.plevels_kilowatts.get("p10") is not None
-                else None,
-                "plevel_90": v.plevels_kilowatts.get("p90") / 1000
-                if v.plevels_kilowatts.get("p90") is not None
-                else None,
+                f"plevel_{p[1:]}": kw / 1000
+                for p, kw in sorted(
+                    v.plevels_kilowatts.items(),
+                    key=lambda item: int(item[0][1:]),
+                )
             },
         )
         for v in all_pgvs

--- a/src/quartz_api/internal/service/uk_national/test_national_router.py
+++ b/src/quartz_api/internal/service/uk_national/test_national_router.py
@@ -41,7 +41,14 @@ async def test_national_forecast_default(api_client, mock_storage: AsyncMock):
             forecaster_version="1.3.0",
             created_timestamp=frozen_time,
             init_timestamp=frozen_time,
-            plevels_kilowatts={"p10": 3800.0, "p90": 4600.0},
+            plevels_kilowatts={
+                "p90": 4600.0,
+                "p2": 3500.0,
+                "p98": 4900.0,
+                "p25": 4000.0,
+                "p75": 4400.0,
+                "p10": 3800.0,
+            },
             metadata={},
         ),
     ]
@@ -56,7 +63,19 @@ async def test_national_forecast_default(api_client, mock_storage: AsyncMock):
 
     # Check kW -> MW formatting
     assert data[0]["expectedPowerGenerationMegawatts"] == 4.2
-    assert data[0]["plevels"]["plevel_10"] == 3.8
+
+    # check the p-level sorting
+    assert list(data[0]["plevels"].keys()) == [
+        "plevel_2", "plevel_10", "plevel_25", "plevel_75", "plevel_90", "plevel_98",
+    ]
+    assert data[0]["plevels"] == {
+        "plevel_2": 3.5,
+        "plevel_10": 3.8,
+        "plevel_25": 4.0,
+        "plevel_75": 4.4,
+        "plevel_90": 4.6,
+        "plevel_98": 4.9,
+    }
 
     # Verify the database was called with the correct defaults
     mock_storage.get_predicted_generation.assert_called()


### PR DESCRIPTION
# Pull Request

## Description

Pass all 7 p-levels from DP to API 

Note: in DP we store the result as p02 but api will pass p2 (not 02)

## How Has This Been Tested?

- [x] Locally 

Resp of `/v0/solar/GB/national/forecast`  

```
[
   {
      "targetTime":"2026-07-13T05:00:00Z",
      "expectedPowerGenerationMegawatts":347.01,
      "plevels":{
         "plevel_10":219.894,
         "plevel_90":456.591
      }
   },
...
   {
      "targetTime":"2026-07-15T08:00:00Z",
      "expectedPowerGenerationMegawatts":4292.49,
      "plevels":{
         "plevel_2":3672.283,
         "plevel_10":3914.082,
         "plevel_25":4076.256,
         "plevel_75":4469.271,
         "plevel_90":4633.637,
         "plevel_98":4892.238
      }
   },
   {
      "targetTime":"2026-07-15T08:30:00Z",
      "expectedPowerGenerationMegawatts":5213.66,
      "plevels":{
         "plevel_2":4518.946,
         "plevel_10":4789.966,
         "plevel_25":4977.708,
         "plevel_75":5416.745,
         "plevel_90":5605.948,
         "plevel_98":5891.578
      }
   },
...
   {
      "targetTime":"2026-07-16T21:30:00Z",
      "expectedPowerGenerationMegawatts":0.0,
      "plevels":{
         "plevel_2":0.0,
         "plevel_10":0.0,
         "plevel_25":0.0,
         "plevel_75":0.0,
         "plevel_90":0.0,
         "plevel_98":0.0
      }
   },
   {
      "targetTime":"2026-07-16T22:00:00Z",
      "expectedPowerGenerationMegawatts":0.0,
      "plevels":{
         "plevel_2":0.0,
         "plevel_10":0.0,
         "plevel_25":0.0,
         "plevel_75":0.0,
         "plevel_90":0.0,
         "plevel_98":0.0
      }
   }
]
```

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
