### PR TITLE
feat: implement dynamic blackout window in satellite ui

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "rasterio>=1.4.4",
     "xarray>=2026.4.0",
     "timezonefinder>=8.2.4",
+    "astral>=3.2",
 ]
 
 [dependency-groups]

--- a/src/quartz_api/internal/service/satellite/_blackout.py
+++ b/src/quartz_api/internal/service/satellite/_blackout.py
@@ -20,8 +20,9 @@ import datetime as dt
 from astral import Observer
 from astral.sun import sunrise, sunset
 
-# buffer window around sunrise and sunset, so the blackout window is longer than day.
-# This is a bit arbitrary, but it should be long enough to cover the
+# Extend the daylight window by 1 hour before sunrise and after sunset.
+# For example, if sunrise is at 06:00 and sunset is at 18:00,
+# the resulting daylight window is 05:00 to 19:00.
 BLACKOUT_BUFFER = dt.timedelta(hours=1)
 
 

--- a/src/quartz_api/internal/service/satellite/_blackout.py
+++ b/src/quartz_api/internal/service/satellite/_blackout.py
@@ -1,0 +1,67 @@
+"""Sun times for the visible satellite channels' nighttime blackout.
+
+The visible channels carry no signal once the region is dark, so they get zeroed
+out at night. Rather than fixed clock times, the window comes from sunrise and
+sunset at a reference point, so it follows the seasons: a timestamp is dark when
+it falls outside the day's sunrise-to-sunset window, widened by a buffer at each
+end and rounded out to a whole hour.
+
+    first_light, last_light = apply_buffer(*sun_times(ts.date(), lon, lat))
+    dark = not first_light <= ts < last_light
+
+Sun times are looked up per UTC day, which assumes the reference point is close
+enough to the prime meridian for a day's sunrise and sunset to share a UTC date.
+That holds for the UK, and `sunrise` raises for a point where the sun never
+crosses the horizon at all, which is outside the UK bounding box.
+"""
+
+import datetime as dt
+
+from astral import Observer
+from astral.sun import sunrise, sunset
+
+# buffer window around sunrise and sunset, so the blackout window is a bit longer than the day length.
+# This is a bit arbitrary, but it should be long enough to cover the
+BLACKOUT_BUFFER = dt.timedelta(hours=1)
+
+
+def sun_times(day: dt.date, lon: float, lat: float) -> tuple[dt.datetime, dt.datetime]:
+    """Sunrise and sunset at a point on a given day.
+
+    Args:
+        day: UTC day to compute for.
+        lon: Longitude in WGS84 degrees.
+        lat: Latitude in WGS84 degrees.
+
+    Returns:
+        Tuple of (sunrise, sunset) as UTC datetimes.
+    """
+    observer = Observer(latitude=lat, longitude=lon)
+    return (
+        sunrise(observer, date=day, tzinfo=dt.UTC),
+        sunset(observer, date=day, tzinfo=dt.UTC),
+    )
+
+
+def apply_buffer(rise: dt.datetime, set_: dt.datetime) -> tuple[dt.datetime, dt.datetime]:
+    """Widen a sunrise and sunset by the buffer, rounded out to whole hours.
+
+    Both ends round away from midday, so the window only ever grows: the sunrise
+    rounds down to the hour and the sunset up, and anything outside the result is
+    dark by at least the buffer.
+
+    Args:
+        rise: Sunrise to pull earlier.
+        set_: Sunset to push later.
+
+    Returns:
+        Tuple of (first light, last light) as UTC datetimes, on whole hours.
+    """
+    first_light = (rise - BLACKOUT_BUFFER).replace(minute=0, second=0, microsecond=0)
+
+    last_light = set_ + BLACKOUT_BUFFER
+    on_the_hour = last_light.replace(minute=0, second=0, microsecond=0)
+    if last_light > on_the_hour:
+        on_the_hour += dt.timedelta(hours=1)
+
+    return first_light, on_the_hour

--- a/src/quartz_api/internal/service/satellite/_blackout.py
+++ b/src/quartz_api/internal/service/satellite/_blackout.py
@@ -20,7 +20,7 @@ import datetime as dt
 from astral import Observer
 from astral.sun import sunrise, sunset
 
-# buffer window around sunrise and sunset, so the blackout window is a bit longer than the day length.
+# buffer window around sunrise and sunset, so the blackout window is longer than day.
 # This is a bit arbitrary, but it should be long enough to cover the
 BLACKOUT_BUFFER = dt.timedelta(hours=1)
 

--- a/src/quartz_api/internal/service/satellite/_ingest.py
+++ b/src/quartz_api/internal/service/satellite/_ingest.py
@@ -1,4 +1,5 @@
 """Ingest latest satellite data for all channels into S3."""
+import datetime as dt
 import io
 import logging
 
@@ -18,17 +19,19 @@ from quartz_api.internal.s3 import (
     get_s3_client,
 )
 
+from ._blackout import apply_buffer, sun_times
+
 log = logging.getLogger(__name__)
 
 # Bounding box to crop to UK
 LEFT, BOTTOM, RIGHT, TOP = -17.05, 46.49, 11.60, 63.31
 # How far back to backfill missing data (in hours)
 BACKFILL_HOURS = 48
-# Per-channel nighttime cleanup, inversion, and recurring "HH:MM" (UTC) blackout times.
+# Per-channel inversion, and whether to black the channel out while the region is dark.
 LAYER_CONFIG = {
-    "VIS006": {"blackout": ["22:00", "02:00"]},
-    "VIS008": {"blackout": ["22:00", "02:00"]},
-    "IR_016": {"blackout": ["22:00", "02:00"]},
+    "VIS006": {"blackout": True},
+    "VIS008": {"blackout": True},
+    "IR_016": {"blackout": True},
     "IR_039": {},
     "IR_087": {"invert": True},
     "IR_097": {"invert": True},
@@ -39,11 +42,6 @@ LAYER_CONFIG = {
     "WV_073": {"invert": True},
 }
 
-
-def _in_blackout(hhmm: str, window: list[str]) -> bool:
-    """True if "HHMM" falls within the ["HH:MM", "HH:MM"] window (wraps past midnight)."""
-    x, a, b = int(hhmm), int(window[0].replace(":", "")), int(window[1].replace(":", ""))
-    return a <= x <= b if a <= b else x >= a or x <= b
 
 _ingest_running: bool = False
 
@@ -142,6 +140,11 @@ def _run_ingest(sat_type: str) -> tuple[str, str]:
 
     for t_idx, t in window_times:
         ts_str = str(t)[:19].replace("-", "").replace("T", "_").replace(":", "")
+        ts_dt = dt.datetime.fromisoformat(str(t)[:19]).replace(tzinfo=dt.UTC)
+        sunrise, sunset = apply_buffer(
+            *sun_times(ts_dt.date(), (LEFT + RIGHT) / 2, (BOTTOM + TOP) / 2),
+        )
+        is_dark = not sunrise <= ts_dt < sunset
 
         for channel in channels:
             key = f"layers/{channel}/{ts_str}.tif"
@@ -153,7 +156,7 @@ def _run_ingest(sat_type: str) -> tuple[str, str]:
             try:
                 config = LAYER_CONFIG.get(channel, {})
 
-                if "blackout" in config and _in_blackout(ts_str[9:13], config["blackout"]):
+                if config.get("blackout") and is_dark:
                     dst_arr = np.zeros((dst_h, dst_w), dtype=np.float32)
                 else:
                     chan_idx = list(ds.channel.values).index(channel)

--- a/src/quartz_api/internal/service/satellite/test_blackout.py
+++ b/src/quartz_api/internal/service/satellite/test_blackout.py
@@ -1,0 +1,74 @@
+import datetime as dt
+import unittest
+
+from ._blackout import apply_buffer, sun_times
+
+# Middle of the UK bounding box used by the ingest.
+UK_LON, UK_LAT = -2.725, 54.9
+
+# Lit windows through the year, as the ingest builds them. Everything is UTC, so
+# the days either side of a BST switchover must land on the same window as the
+# switchover itself.
+LIT_WINDOWS = [
+    ("2026-01-01", "07:00", "17:00"),  # sun 08:35-15:53
+    ("2026-02-14", "06:00", "19:00"),  # sun 07:35-17:15
+    ("2026-03-20", "05:00", "20:00"),  # spring equinox, sun 06:13-18:24
+    ("2026-03-28", "04:00", "20:00"),  # day before BST starts, sun 05:53-18:39
+    ("2026-03-29", "04:00", "20:00"),  # BST starts, sun 05:50-18:41
+    ("2026-03-30", "04:00", "20:00"),  # day after, sun 05:48-18:43
+    ("2026-05-01", "03:00", "21:00"),  # sun 04:31-19:45
+    ("2026-06-21", "02:00", "22:00"),  # summer solstice, longest day, sun 03:32-20:52
+    ("2026-08-04", "03:00", "22:00"),  # sun 04:25-20:06
+    ("2026-09-22", "04:00", "20:00"),  # autumn equinox, sun 05:56-18:09
+    ("2026-10-24", "05:00", "18:00"),  # day before BST ends, sun 06:58-16:50
+    ("2026-10-25", "06:00", "18:00"),  # BST ends, sun 07:00-16:48
+    ("2026-10-26", "06:00", "18:00"),  # day after, sun 07:02-16:46
+    ("2026-12-21", "07:00", "17:00"),  # winter solstice, shortest day, sun 08:33-15:44
+]
+
+
+class TestSunTimes(unittest.TestCase):
+    def test_sunrise_and_sunset_over_the_uk(self) -> None:
+        rise, set_ = sun_times(dt.date(2026, 6, 21), UK_LON, UK_LAT)
+
+        self.assertEqual(rise.strftime("%H:%M"), "03:32")
+        self.assertEqual(set_.strftime("%H:%M"), "20:52")
+
+
+class TestApplyBuffer(unittest.TestCase):
+    def test_sunrise_rounds_down_and_sunset_up(self) -> None:
+        rise = dt.datetime(2026, 6, 21, 3, 32, tzinfo=dt.UTC)
+        set_ = dt.datetime(2026, 6, 21, 20, 52, tzinfo=dt.UTC)
+
+        self.assertEqual(
+            apply_buffer(rise, set_),
+            (
+                dt.datetime(2026, 6, 21, 2, 0, tzinfo=dt.UTC),
+                dt.datetime(2026, 6, 21, 22, 0, tzinfo=dt.UTC),
+            ),
+        )
+
+    def test_events_already_on_the_hour(self) -> None:
+        rise = dt.datetime(2026, 6, 21, 4, 0, tzinfo=dt.UTC)
+        set_ = dt.datetime(2026, 6, 21, 20, 0, tzinfo=dt.UTC)
+
+        self.assertEqual(
+            apply_buffer(rise, set_),
+            (
+                dt.datetime(2026, 6, 21, 3, 0, tzinfo=dt.UTC),
+                dt.datetime(2026, 6, 21, 21, 0, tzinfo=dt.UTC),
+            ),
+        )
+
+
+class TestLitWindowThroughTheYear(unittest.TestCase):
+    def test_windows(self) -> None:
+        for day, first_light, last_light in LIT_WINDOWS:
+            with self.subTest(day=day):
+                start, end = apply_buffer(
+                    *sun_times(dt.date.fromisoformat(day), UK_LON, UK_LAT),
+                )
+                self.assertEqual(
+                    (start.strftime("%H:%M"), end.strftime("%H:%M")),
+                    (first_light, last_light),
+                )

--- a/uv.lock
+++ b/uv.lock
@@ -239,6 +239,18 @@ fastapi = [
 ]
 
 [[package]]
+name = "astral"
+version = "3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/d1/1adbf06a38dc339e41a1666f6c7135924594c20fd46e060fb263248c564d/astral-3.2.tar.gz", hash = "sha256:9b7c3b412e9e69d172cfb24be0e6addcc9f1bd01a28db8bebe66d75ccc533d88", size = 48075, upload-time = "2022-11-05T18:12:02.913Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/80/d6edd9c3259913cfe39aff2bea4da65de5ad0235a578405e37aabace5f2c/astral-3.2-py3-none-any.whl", hash = "sha256:cb7b49a3f0d4c64ae666be131276d2a3226134c598db10e672028cf8ff855f83", size = 38325, upload-time = "2022-11-05T18:12:01.164Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2359,6 +2371,7 @@ name = "quartz-api"
 source = { editable = "." }
 dependencies = [
     { name = "apitally", extra = ["fastapi"] },
+    { name = "astral" },
     { name = "auth0-fastapi-api" },
     { name = "cryptography" },
     { name = "dp-sdk" },
@@ -2410,6 +2423,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "apitally", extras = ["fastapi"], specifier = ">=0.22.3" },
+    { name = "astral", specifier = ">=3.2" },
     { name = "auth0-fastapi-api", specifier = ">=1.0.0b5" },
     { name = "cryptography", specifier = ">=41.0.0" },
     { name = "dp-sdk", url = "https://github.com/openclimatefix/data-platform/releases/download/v0.32.0/dp_sdk-0.32.0-py3-none-any.whl" },


### PR DESCRIPTION
# Pull Request

## Description

Implements dynamic blackout window according to the dates
```
Jan 01 blackout 17:00 -> 07:00   night 14h
Feb 01 blackout 18:00 -> 06:00   night 13h
Mar 01 blackout 19:00 -> 05:00   night 11h
Apr 01 blackout 20:00 -> 04:00   night  8h
May 01 blackout 21:00 -> 03:00   night  6h
Jun 01 blackout 22:00 -> 02:00   night  4h
Jul 01 blackout 22:00 -> 02:00   night  4h
Aug 01 blackout 22:00 -> 03:00   night  5h
Sep 01 blackout 21:00 -> 04:00   night  7h
Oct 01 blackout 19:00 -> 05:00   night 10h
Nov 01 blackout 18:00 -> 06:00   night 12h
Dec 01 blackout 17:00 -> 07:00   night 14h
```

## How Has This Been Tested?

- [x] Locally 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
