### PR TITLE
fix: update satellite bucket names to include environment suffix

### DIFF
--- a/src/quartz_api/cmd/server.conf
+++ b/src/quartz_api/cmd/server.conf
@@ -81,9 +81,9 @@ apitally {
 satellite {
   aws_region = "eu-west-1"
   aws_region = ${?AWS_DEFAULT_REGION}
-  geotiff_bucket = "historical-cloud-data-geotiff"
+  geotiff_bucket = "historical-cloud-data-geotiff-"${api.environment}
   geotiff_bucket = ${?HISTORIC_SAT_S3_BUCKET}
-  source_bucket = "nowcasting-sat-development"
+  source_bucket = "nowcasting-sat-"${api.environment}
   source_bucket = ${?RAW_SAT_S3_BUCKET}
   icechunk_bucket = "nowcasting-sat-icechunk"
   icechunk_bucket = ${?ICECHUNK_S3_BUCKET}


### PR DESCRIPTION
# Pull Request

## Description

update satellite bucket names to include environment suffix

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
