### PR TITLE
fix: update icechunk bucket name to include environment suffix

### DIFF
--- a/src/quartz_api/cmd/server.conf
+++ b/src/quartz_api/cmd/server.conf
@@ -85,7 +85,7 @@ satellite {
   geotiff_bucket = ${?HISTORIC_SAT_S3_BUCKET}
   source_bucket = "nowcasting-sat-"${api.environment}
   source_bucket = ${?RAW_SAT_S3_BUCKET}
-  icechunk_bucket = "nowcasting-sat-icechunk"
+  icechunk_bucket = "nowcasting-sat-"${api.environment}
   icechunk_bucket = ${?ICECHUNK_S3_BUCKET}
   icechunk_prefix = "sat"
   icechunk_prefix = ${?ICECHUNK_S3_PREFIX}


### PR DESCRIPTION
# Pull Request

## Description

update icechunk bucket name to include environment suffix

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
