### PR TITLE
fix: use created_cutoff for pivot timestamp

### DIFF
--- a/src/quartz_api/internal/backends/dataplatform/client.py
+++ b/src/quartz_api/internal/backends/dataplatform/client.py
@@ -141,13 +141,10 @@ class StorageClient(models.StorageInterface):
         if forecaster_name is None:
             # Use the forecaster that produced the most recent forecast for the location by default,
             # taking into account the desired horizon.
-            # NOTE: This is a pretty rough-and-ready way of getting the forecaster and should be
-            # changed.
             req = messages_pb2.GetLatestForecastsRequest(
                 location_uuid=str(location_uuid),
                 energy_source=energy_type_map[energy_type],
-                pivot_timestamp_utc=window_start
-                - dt.timedelta(minutes=forecast_horizon_minutes),
+                pivot_timestamp_utc=created_cutoff,
             )
             resp = await self.dpc.GetLatestForecasts(req)
             if len(resp.forecasts) == 0:


### PR DESCRIPTION
# Pull Request

## Description

- use `created_cutoff` for `pivot_timestamp_utc` instead of `window_start`
- previously, `pivot_timestamp_utc` was set from window_start, which is typically days in the past - so `GetLatestForecasts` picked whichever forecaster looked freshest at that past point in time.

Fixes #https://github.com/openclimatefix/client-private/issues/590

## How Has This Been Tested?

- [x] tested locally with dev data-platform

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
