### PR TITLE
fix: update forecaster names for solar and wind regions

### DIFF
--- a/src/quartz_api/internal/service/regions/router.py
+++ b/src/quartz_api/internal/service/regions/router.py
@@ -38,8 +38,8 @@ _REGION_OBSERVER_NAME = "ruvnl"
 
 # Pinned per source, so every horizon of a chart is served by the same model.
 _REGION_FORECASTER_NAMES: dict[str, str] = {
-    "solar": "pvnet_india",
-    "wind": "windnet_india_mo_v2",
+    "solar": "pvnet_india_adjust",
+    "wind": "windnet_india_mo_v2_adjust",
 }
 
 


### PR DESCRIPTION
# Pull Request

## Description

- updated forecaster names to use `*_adjust`

Fixes #https://github.com/openclimatefix/client-private/issues/593

## How Has This Been Tested?

- [x] tested locally with dev data-platform

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
