### PR TITLE
Finalise/simplify GB model names; make the trend adjuster a boolean

### DIFF
--- a/src/quartz_api/internal/service/v1/cache.py
+++ b/src/quartz_api/internal/service/v1/cache.py
@@ -166,7 +166,7 @@ async def warm_v1_forecast_cache(
                 energy_type=energy_type,
                 location_type=rt.location_type,
                 authdata={},
-                forecaster_name=rt.default_model,
+                forecaster_name=rt.default_forecaster_name(),
             )
             if pgvs:
                 if first_found_pgv is None:

--- a/src/quartz_api/internal/service/v1/country_config.py
+++ b/src/quartz_api/internal/service/v1/country_config.py
@@ -257,8 +257,9 @@ class FM:
     NL_UNCURTAILED = ForecastModel(
         name="nl_regional_pv_ecmwf_mo_sat_uncurtailed",
         label="PV + ECMWF + Met Office + Satellite, Uncurtailed",
-        slug="ecmwf_mo_sat_uncurtailed",
+        slug="ecmwf_mo_pv_sat_uncurtailed",
         adjust_name="nl_regional_pv_ecmwf_mo_sat_uncurtailed_adjust",
+        aliases=("ecmwf_mo_sat_uncurtailed",),
         adjust_aliases=("ecmwf_mo_sat_uncurtailed_adjust",),
     )
 

--- a/src/quartz_api/internal/service/v1/country_config.py
+++ b/src/quartz_api/internal/service/v1/country_config.py
@@ -16,16 +16,48 @@ class ForecastModel:
     `name` is the internal DP forecaster_name sent to the data platform.
     `slug` is the user-facing API name (defaults to `name` when not set).
     `label` is the human-readable display name.
+    `adjust_name` is the trend-adjusted variant the `adjusted` param selects; None
+    means there is none and the param is a no-op here.
+
+    `aliases` and `adjust_aliases` are retired user-facing names, still accepted but
+    absent from `/region-types`, the OpenAPI enum and error messages. `aliases` pins
+    the adjuster off and `adjust_aliases` pins it on, so an old name keeps the exact
+    forecast it returned before the adjuster became a parameter.
     """
 
     name: str
     label: str
     slug: str | None = None
+    adjust_name: str | None = None
+    aliases: tuple[str, ...] = ()
+    adjust_aliases: tuple[str, ...] = ()
 
     @property
     def api_name(self) -> str:
         """User-facing model name used in API params and enum values."""
         return self.slug if self.slug is not None else self.name
+
+    def accepts(self, api_name: str) -> bool:
+        """True if `api_name` names this model, current or legacy."""
+        return (
+            api_name == self.api_name
+            or api_name in self.aliases
+            or api_name in self.adjust_aliases
+        )
+
+    def alias_adjust_override(self, api_name: str) -> bool | None:
+        """Trend-adjuster state implied by a legacy name, or None if it implies nothing."""
+        if api_name in self.adjust_aliases:
+            return True
+        if api_name in self.aliases:
+            return False
+        return None
+
+    def internal_name(self, *, adjusted: bool) -> str:
+        """Internal DP forecaster_name for this model at the given adjuster setting."""
+        if adjusted and self.adjust_name is not None:
+            return self.adjust_name
+        return self.name
 
 
 @dataclass(frozen=True)
@@ -38,8 +70,10 @@ class RegionTypeConfig:
     location_type: LocationType
     source_types: tuple[str, ...] = ()
     forecast_models: tuple[ForecastModel, ...] = ()
-    # default_model stores the internal DP forecaster_name, not the user-facing slug.
+    # Internal DP forecaster_name, unadjusted — the `adjusted` param reaches the variant.
     default_model: str | None = None
+    # False (e.g. GB gsp) means no adjusted variants exist, so `adjusted` is a no-op.
+    supports_adjusted: bool = False
     metadata_fields: tuple[str, ...] = ()
     # intraday_models lists models accessible to intraday-only users (subset of forecast_models).
     intraday_models: tuple[ForecastModel, ...] = ()
@@ -56,18 +90,29 @@ class RegionTypeConfig:
         return None
 
     def get_model_by_api_name(self, api_name: str) -> ForecastModel | None:
-        """Look up a ForecastModel by its user-facing API name (slug or internal name)."""
+        """Look up a ForecastModel by its user-facing API name, current or legacy."""
         for fm in self.forecast_models:
-            if fm.api_name == api_name:
+            if fm.accepts(api_name):
                 return fm
         return None
 
     def get_model_by_internal_name(self, name: str) -> ForecastModel | None:
-        """Look up a ForecastModel by its internal DP name."""
+        """Look up a ForecastModel by its internal DP name, adjusted or not."""
         for fm in self.forecast_models:
-            if fm.name == name:
+            if name in (fm.name, fm.adjust_name):
                 return fm
         return None
+
+    def default_forecaster_name(self, *, adjusted: bool = True) -> str | None:
+        """Internal DP forecaster_name for the default model at the given adjuster setting."""
+        if self.default_model is None:
+            return None
+        fm = self.get_model_by_internal_name(self.default_model)
+        if fm is None:
+            return self.default_model
+        return fm.internal_name(
+            adjusted=adjusted and self.supports_adjusted,
+        )
 
     def default_model_api_name(self) -> str | None:
         """User-facing API name for the default forecast model."""
@@ -151,98 +196,92 @@ class FM:
     in any RegionTypeConfig tuple.
     """
 
-    # GB — blend
-    BLEND = ForecastModel(name="blend", label="Blend")
-    BLEND_ADJUST = ForecastModel(name="blend_adjust", label="Blend (Trend Adjusted)")
-    # GB — PVNet single-source models
-    PVNET_ECMWF = ForecastModel(name="pvnet_ecmwf", label="PVNet Intraday (ECMWF)")
-    PVNET_ECMWF_ADJUST = ForecastModel(
-        name="pvnet_ecmwf_adjust",
-        label="PVNet Intraday (ECMWF, Trend Adjusted)",
+    # GB — blend of all models
+    BLEND = ForecastModel(
+        name="blend",
+        label="Blend",
+        adjust_name="blend_adjust",
+        adjust_aliases=("blend_adjust",),
     )
-    PVNET_SAT = ForecastModel(
-        name="pvnet_sat_only",
-        label="PVNet Intraday (Satellite)",
-        slug="pvnet_sat",
+    # GB — NWP-only day-ahead (ECMWF + Met Office, no satellite at day-ahead range)
+    ECMWF_MO = ForecastModel(
+        name="pvnet_day_ahead",
+        label="ECMWF + Met Office",
+        slug="ecmwf_mo",
+        adjust_name="pvnet_day_ahead_adjust",
+        aliases=("pvnet_day_ahead",),
+        adjust_aliases=("pvnet_day_ahead_adjust",),
     )
-    PVNET_SAT_ADJUST = ForecastModel(
-        name="pvnet_sat_only_adjust",
-        label="PVNet Intraday (Satellite, Trend Adjusted)",
-        slug="pvnet_sat_adjust",
-    )
-    PVNET_UKV = ForecastModel(
-        name="pvnet_ukv_only",
-        label="PVNet Intraday (Met Office)",
-        slug="pvnet_ukv",
-    )
-    PVNET_UKV_ADJUST = ForecastModel(
-        name="pvnet_ukv_only_adjust",
-        label="PVNet Intraday (Met Office, Trend Adjusted)",
-        slug="pvnet_ukv_adjust",
-    )
-    # GB — PVNet v2 (intraday)
-    PVNET_INTRADAY = ForecastModel(
+    # GB — full intraday input set
+    ECMWF_MO_SAT_8H = ForecastModel(
         name="pvnet_v2",
-        label="PVNet Intraday",
-        slug="pvnet_intraday",
+        label="ECMWF + Met Office + Satellite (8h)",
+        slug="ecmwf_mo_sat_8h",
+        adjust_name="pvnet_v2_adjust",
+        aliases=("pvnet_intraday",),
+        adjust_aliases=("pvnet_intraday_adjust",),
     )
-    PVNET_INTRADAY_ADJUST = ForecastModel(
-        name="pvnet_v2_adjust",
-        label="PVNet Intraday (Trend Adjusted)",
-        slug="pvnet_intraday_adjust",
+    # GB — single-input ablation models
+    ECMWF = ForecastModel(
+        name="pvnet_ecmwf",
+        label="ECMWF",
+        slug="ecmwf",
+        adjust_name="pvnet_ecmwf_adjust",
+        aliases=("pvnet_ecmwf",),
+        adjust_aliases=("pvnet_ecmwf_adjust",),
     )
-    # GB — PVNet day-ahead
-    PVNET_DAY_AHEAD = ForecastModel(name="pvnet_day_ahead", label="PVNet Day Ahead")
-    PVNET_DAY_AHEAD_ADJUST = ForecastModel(
-        name="pvnet_day_ahead_adjust",
-        label="PVNet Day Ahead (Trend Adjusted)",
+    SAT_8H = ForecastModel(
+        name="pvnet_sat_only",
+        label="Satellite (8h)",
+        slug="sat_8h",
+        adjust_name="pvnet_sat_only_adjust",
+        aliases=("pvnet_sat",),
+        adjust_aliases=("pvnet_sat_adjust",),
+    )
+    MO = ForecastModel(
+        name="pvnet_ukv_only",
+        label="Met Office",
+        slug="mo",
+        adjust_name="pvnet_ukv_only_adjust",
+        aliases=("pvnet_ukv",),
+        adjust_aliases=("pvnet_ukv_adjust",),
     )
     # NL — blend (slugs match GB blend slugs so API is consistent across countries)
-    NL_BLEND = ForecastModel(name="nl_blend", label="Blend", slug="blend")
-    NL_BLEND_ADJUST = ForecastModel(
-        name="nl_blend_adjust",
-        label="Blend (Trend Adjusted)",
-        slug="blend_adjust",
+    NL_BLEND = ForecastModel(
+        name="nl_blend",
+        label="Blend",
+        slug="blend",
+        adjust_name="nl_blend_adjust",
+        adjust_aliases=("blend_adjust",),
     )
     # NL — uncurtailed (regional and national)
     NL_UNCURTAILED = ForecastModel(
         name="nl_regional_pv_ecmwf_mo_sat_uncurtailed",
         label="PV + ECMWF + Met Office + Satellite, Uncurtailed",
         slug="ecmwf_mo_sat_uncurtailed",
-    )
-    NL_UNCURTAILED_ADJUST = ForecastModel(
-        name="nl_regional_pv_ecmwf_mo_sat_uncurtailed_adjust",
-        label="PV + ECMWF + Met Office + Satellite, Uncurtailed (Trend Adjusted)",
-        slug="ecmwf_mo_sat_uncurtailed_adjust",
+        adjust_name="nl_regional_pv_ecmwf_mo_sat_uncurtailed_adjust",
+        adjust_aliases=("ecmwf_mo_sat_uncurtailed_adjust",),
     )
 
 
 _GB_NATIONAL_FORECAST_MODELS = (
     FM.BLEND,
-    FM.BLEND_ADJUST,
-    FM.PVNET_ECMWF,
-    FM.PVNET_ECMWF_ADJUST,
-    FM.PVNET_SAT,
-    FM.PVNET_SAT_ADJUST,
-    FM.PVNET_UKV,
-    FM.PVNET_UKV_ADJUST,
-    FM.PVNET_INTRADAY,
-    FM.PVNET_INTRADAY_ADJUST,
-    FM.PVNET_DAY_AHEAD,
-    FM.PVNET_DAY_AHEAD_ADJUST,
+    FM.ECMWF_MO,
+    FM.ECMWF_MO_SAT_8H,
+    FM.ECMWF,
+    FM.SAT_8H,
+    FM.MO,
 )
 
 _GB_GSP_FORECAST_MODELS = (
     FM.BLEND,
-    FM.PVNET_INTRADAY,
-    FM.PVNET_DAY_AHEAD,
+    FM.ECMWF_MO_SAT_8H,
+    FM.ECMWF_MO,
 )
 
 _NL_NATIONAL_FORECAST_MODELS = (
     FM.NL_BLEND,
-    FM.NL_BLEND_ADJUST,
     FM.NL_UNCURTAILED,
-    FM.NL_UNCURTAILED_ADJUST,
 )
 
 _NL_REGIONAL_FORECAST_MODELS = (FM.NL_BLEND, FM.NL_UNCURTAILED)
@@ -262,9 +301,10 @@ COUNTRIES: dict[str, CountryConfig] = {
                 location_type=LocationType.NATION,
                 source_types=("solar",),
                 forecast_models=_GB_NATIONAL_FORECAST_MODELS,
-                default_model="blend_adjust",
-                intraday_models=(FM.PVNET_INTRADAY, FM.PVNET_INTRADAY_ADJUST),
-                intraday_default_model=FM.PVNET_INTRADAY_ADJUST,
+                default_model="blend",
+                supports_adjusted=True,
+                intraday_models=(FM.ECMWF_MO_SAT_8H,),
+                intraday_default_model=FM.ECMWF_MO_SAT_8H,
             ),
             RegionTypeConfig(
                 type="gsp",
@@ -275,8 +315,8 @@ COUNTRIES: dict[str, CountryConfig] = {
                 forecast_models=_GB_GSP_FORECAST_MODELS,
                 default_model="blend",
                 metadata_fields=("gsp_id", "full_name"),
-                intraday_models=(FM.PVNET_INTRADAY,),
-                intraday_default_model=FM.PVNET_INTRADAY,
+                intraday_models=(FM.ECMWF_MO_SAT_8H,),
+                intraday_default_model=FM.ECMWF_MO_SAT_8H,
             ),
         ),
         generation_sources=(
@@ -305,7 +345,8 @@ COUNTRIES: dict[str, CountryConfig] = {
                 location_type=LocationType.NATION,
                 source_types=("solar",),
                 forecast_models=_NL_NATIONAL_FORECAST_MODELS,
-                default_model="nl_blend_adjust",
+                default_model="nl_blend",
+                supports_adjusted=True,
             ),
             RegionTypeConfig(
                 type="province",

--- a/src/quartz_api/internal/service/v1/country_config.py
+++ b/src/quartz_api/internal/service/v1/country_config.py
@@ -37,17 +37,6 @@ class ForecastModel:
         """User-facing model name used in API params and enum values."""
         return self.slug if self.slug is not None else self.name
 
-    def accepts(self, api_name: str, *, adjust_aliases_ok: bool = True) -> bool:
-        """True if `api_name` names this model, current or legacy.
-
-        An `_adjust` alias names a variant that does not exist where the region type
-        has no adjusted models, so those region types pass adjust_aliases_ok=False
-        and reject the name instead of silently serving the unadjusted forecast.
-        """
-        if api_name in (self.api_name, *self.aliases):
-            return True
-        return adjust_aliases_ok and api_name in self.adjust_aliases
-
     def alias_adjust_override(self, api_name: str) -> bool | None:
         """Trend-adjuster state implied by a legacy name, or None if it implies nothing."""
         if api_name in self.adjust_aliases:
@@ -93,9 +82,16 @@ class RegionTypeConfig:
         return None
 
     def get_model_by_api_name(self, api_name: str) -> ForecastModel | None:
-        """Look up a ForecastModel by its user-facing API name, current or legacy."""
+        """Look up a ForecastModel by its user-facing API name, current or legacy.
+
+        An `_adjust` alias names a variant that does not exist where this region type
+        has no adjusted models, so it is unknown there rather than resolving to the
+        plain forecast.
+        """
         for fm in self.forecast_models:
-            if fm.accepts(api_name, adjust_aliases_ok=self.supports_adjusted):
+            if api_name in (fm.api_name, *fm.aliases):
+                return fm
+            if self.supports_adjusted and api_name in fm.adjust_aliases:
                 return fm
         return None
 

--- a/src/quartz_api/internal/service/v1/country_config.py
+++ b/src/quartz_api/internal/service/v1/country_config.py
@@ -37,13 +37,16 @@ class ForecastModel:
         """User-facing model name used in API params and enum values."""
         return self.slug if self.slug is not None else self.name
 
-    def accepts(self, api_name: str) -> bool:
-        """True if `api_name` names this model, current or legacy."""
-        return (
-            api_name == self.api_name
-            or api_name in self.aliases
-            or api_name in self.adjust_aliases
-        )
+    def accepts(self, api_name: str, *, adjust_aliases_ok: bool = True) -> bool:
+        """True if `api_name` names this model, current or legacy.
+
+        An `_adjust` alias names a variant that does not exist where the region type
+        has no adjusted models, so those region types pass adjust_aliases_ok=False
+        and reject the name instead of silently serving the unadjusted forecast.
+        """
+        if api_name in (self.api_name, *self.aliases):
+            return True
+        return adjust_aliases_ok and api_name in self.adjust_aliases
 
     def alias_adjust_override(self, api_name: str) -> bool | None:
         """Trend-adjuster state implied by a legacy name, or None if it implies nothing."""
@@ -92,7 +95,7 @@ class RegionTypeConfig:
     def get_model_by_api_name(self, api_name: str) -> ForecastModel | None:
         """Look up a ForecastModel by its user-facing API name, current or legacy."""
         for fm in self.forecast_models:
-            if fm.accepts(api_name):
+            if fm.accepts(api_name, adjust_aliases_ok=self.supports_adjusted):
                 return fm
         return None
 

--- a/src/quartz_api/internal/service/v1/country_config.py
+++ b/src/quartz_api/internal/service/v1/country_config.py
@@ -256,7 +256,7 @@ class FM:
     # NL — uncurtailed (regional and national)
     NL_UNCURTAILED = ForecastModel(
         name="nl_regional_pv_ecmwf_mo_sat_uncurtailed",
-        label="PV + ECMWF + Met Office + Satellite, Uncurtailed",
+        label="ECMWF + Met Office + PV + Satellite, Uncurtailed",
         slug="ecmwf_mo_pv_sat_uncurtailed",
         adjust_name="nl_regional_pv_ecmwf_mo_sat_uncurtailed_adjust",
         aliases=("ecmwf_mo_sat_uncurtailed",),

--- a/src/quartz_api/internal/service/v1/endpoint_types.py
+++ b/src/quartz_api/internal/service/v1/endpoint_types.py
@@ -261,6 +261,12 @@ class RegionType(BaseModel):
     level: int
     default_model: str | None = None
     forecast_models: list[ForecastModel] = []
+    supports_adjusted: bool = False
+    """Whether the `adjusted` param has any effect for this region type.
+
+    False means there are no trend-adjusted model variants at this granularity and the
+    param is silently ignored.
+    """
 
 
 class CountryDetail(BaseModel):

--- a/src/quartz_api/internal/service/v1/helpers.py
+++ b/src/quartz_api/internal/service/v1/helpers.py
@@ -287,7 +287,8 @@ def resolve_forecast_model(
 
     fm = rt.get_model_by_api_name(model)
     if fm is None:
-        # Unknown name — validate_model returns 400 error at the routes that call it.
+        # Only reachable for a region type with no configured models — every route
+        # calls validate_model first, which 400s an unknown name against a real list.
         return model
     if is_intraday_only and rt.intraday_models and fm not in rt.intraday_models:
         raise HTTPException(

--- a/src/quartz_api/internal/service/v1/helpers.py
+++ b/src/quartz_api/internal/service/v1/helpers.py
@@ -16,6 +16,7 @@ from quartz_api.internal.middleware.auth import AuthDependency
 from .auth_scopes import ALL_COUNTRY_PERMISSIONS
 from .country_config import (
     CountryConfig,
+    ForecastModel,
     RegionTypeConfig,
 )
 from .endpoint_types import Centroid, RegionDetail, RegionSummary
@@ -132,8 +133,9 @@ def validate_model(
     """Raise 400 if model is provided but not listed for the region type."""
     if model is None or rt is None or not rt.forecast_models:
         return
-    valid = {f.api_name for f in rt.forecast_models}
-    if model not in valid:
+    if rt.get_model_by_api_name(model) is None:
+        # Only current names are advertised — retired aliases resolve but stay unlisted.
+        valid = {f.api_name for f in rt.forecast_models}
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Model '{model}' is not available for region type '{region_type_label}'. "
@@ -248,48 +250,57 @@ def check_country_access(auth: AuthDependency, cfg: CountryConfig) -> bool:
     )
 
 
+def _default_forecast_model(
+    rt: RegionTypeConfig,
+    is_intraday_only: bool,
+) -> ForecastModel | None:
+    """The model to use when the caller named none, or None if none is configured."""
+    if is_intraday_only and rt.intraday_models:
+        # Naming nothing must not yield a model naming it would 403 on.
+        return rt.intraday_default_model or rt.intraday_models[0]
+    if rt.default_model is None:
+        return None
+    return rt.get_model_by_internal_name(rt.default_model)
+
+
 def resolve_forecast_model(
     model: str | None,
     rt: RegionTypeConfig | None,
     is_intraday_only: bool,
+    adjusted: bool = True,
 ) -> str | None:
-    """Validate and resolve the forecast model, returning the internal DP name.
+    """Resolve a user-facing model name to the internal DP forecaster_name.
 
-    Some models have a user-facing slug (api_name) that differs from the internal DP
-    forecaster_name — e.g. pvnet_v2 is exposed as "pvnet_intraday".  This function:
-      1. Picks the default model if none was requested (intraday default for restricted users)
-      2. Validates intraday-only users can only request intraday models (HTTP 403 otherwise)
-      3. Translates the slug back to the raw DP forecaster_name before the backend call
+    User-facing names are slugs that differ from the DP forecaster_name — pvnet_v2 is
+    exposed as "ecmwf_mo_sat_8h" — and retired slugs are still accepted as aliases.
+    Raises 403 if an intraday-only caller names a model outside their permitted set.
     """
     if rt is None:
         return model
-    if is_intraday_only and rt.intraday_models:
-        allowed = rt.intraday_api_names()
-        if model is not None and model not in allowed:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=(
-                    f"Model '{model}' is not available with your current access level. "
-                    f"Intraday-accessible models: {sorted(allowed)}"
-                ),
-            )
-        resolved_api = model or (
-            rt.intraday_default_model.api_name if rt.intraday_default_model else None
+
+    if model is None:
+        fm = _default_forecast_model(rt, is_intraday_only)
+        if fm is None:
+            # None sends no forecaster_name, so the DP selects the forecaster.
+            return rt.default_model
+        return fm.internal_name(adjusted=adjusted and rt.supports_adjusted)
+
+    fm = rt.get_model_by_api_name(model)
+    if fm is None:
+        # Unknown name — validate_model returns 400 error at the routes that call it.
+        return model
+    if is_intraday_only and rt.intraday_models and fm not in rt.intraday_models:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"Model '{model}' is not available with your current access level. "
+                f"Intraday-accessible models: {sorted(rt.intraday_api_names())}"
+            ),
         )
-    else:
-        _default_fm = (
-            rt.get_model_by_internal_name(rt.default_model)
-            if rt.default_model
-            else None
-        )
-        resolved_api = model or (
-            _default_fm.api_name if _default_fm else rt.default_model
-        )
-    # Translate api_name → internal DP name before the backend call.
-    if resolved_api is not None:
-        fm = rt.get_model_by_api_name(resolved_api)
-        return fm.name if fm else resolved_api
-    return None
+    # A retired alias pins its own adjuster state, keeping its pre-rename result.
+    override = fm.alias_adjust_override(model)
+    use_adjusted = adjusted if override is None else override
+    return fm.internal_name(adjusted=use_adjusted and rt.supports_adjusted)
 
 
 def internal_to_api_name(

--- a/src/quartz_api/internal/service/v1/routes/discovery.py
+++ b/src/quartz_api/internal/service/v1/routes/discovery.py
@@ -90,6 +90,7 @@ async def get_countries(
                         label=rt.label,
                         level=rt.level,
                         default_model=rt.default_model_api_name(),
+                        supports_adjusted=rt.supports_adjusted,
                         forecast_models=[
                             ForecastModel(name=f.api_name, label=f.label)
                             for f in rt.forecast_models
@@ -136,7 +137,8 @@ async def get_region_types(
             type=rt.type,
             label=rt.label,
             level=rt.level,
-            default_model=rt.default_model,
+            default_model=rt.default_model_api_name(),
+            supports_adjusted=rt.supports_adjusted,
             forecast_models=[
                 ForecastModel(name=f.api_name, label=f.label)
                 for f in rt.forecast_models

--- a/src/quartz_api/internal/service/v1/routes/forecasts.py
+++ b/src/quartz_api/internal/service/v1/routes/forecasts.py
@@ -212,6 +212,7 @@ async def get_forecast_last_updated_timestamp(
         )
     location_type = locs[0].location_type or models.LocationType.NATION
     rt = country.location_type_to_region_type(location_type)
+    validate_model(model, rt, location_type.name)
     model = resolve_forecast_model(model, rt, is_intraday_only, adjusted)
 
     now = dt.datetime.now(tz=dt.UTC)

--- a/src/quartz_api/internal/service/v1/routes/forecasts.py
+++ b/src/quartz_api/internal/service/v1/routes/forecasts.py
@@ -87,6 +87,14 @@ async def get_forecast(
         ),
     ),
     model: ValidForecastModel | None = None,
+    adjusted: bool = Query(
+        True,
+        description=(
+            "Apply the trend adjuster, which corrects the forecast using the last "
+            "week of observed error. On by default. Ignored for region types with no "
+            "adjusted model variants (e.g. GB `gsp`)."
+        ),
+    ),
 ) -> ForecastResponse:
     """Get the solar generation forecast for a specific region.
 
@@ -114,7 +122,7 @@ async def get_forecast(
     location_type = region.location_type or models.LocationType.NATION
     rt = country.location_type_to_region_type(location_type)
     validate_model(model, rt, location_type.name)
-    model = resolve_forecast_model(model, rt, is_intraday_only)
+    model = resolve_forecast_model(model, rt, is_intraday_only, adjusted)
 
     now = pd.Timestamp.utcnow().floor("30min").to_pydatetime()
     win_start = start_utc or now
@@ -173,6 +181,14 @@ async def get_forecast_last_updated_timestamp(
     db: models.StorageClientDependency,
     auth: AuthDependency,
     model: ValidForecastModel | None = None,
+    adjusted: bool = Query(
+        True,
+        description=(
+            "Apply the trend adjuster, which corrects the forecast using the last "
+            "week of observed error. On by default. Ignored for region types with no "
+            "adjusted model variants (e.g. GB `gsp`)."
+        ),
+    ),
 ) -> dt.datetime:
     """Return the creation time of the most recent forecast for a region.
 
@@ -196,7 +212,7 @@ async def get_forecast_last_updated_timestamp(
         )
     location_type = locs[0].location_type or models.LocationType.NATION
     rt = country.location_type_to_region_type(location_type)
-    model = resolve_forecast_model(model, rt, is_intraday_only)
+    model = resolve_forecast_model(model, rt, is_intraday_only, adjusted)
 
     now = dt.datetime.now(tz=dt.UTC)
     pgvs = await db.get_predicted_generation(
@@ -233,6 +249,14 @@ async def get_forecasts_at_time(
     region_type: ValidRegionType,
     model_name: ValidForecastModel | None = None,
     model_version: str | None = Query(None, description="Forecast model version."),
+    adjusted: bool = Query(
+        True,
+        description=(
+            "Apply the trend adjuster, which corrects the forecast using the last "
+            "week of observed error. On by default. Ignored for region types with no "
+            "adjusted model variants (e.g. GB `gsp`)."
+        ),
+    ),
     time_utc: dt.datetime | None = Query(
         None,
         description="Forecast target time (UTC). Defaults to now floored to 30 minutes.",
@@ -254,7 +278,12 @@ async def get_forecasts_at_time(
             detail=f"Unknown region type '{region_type}' for {country.code}.",
         )
     validate_model(model_name, rt, rt.type)
-    model_name = resolve_forecast_model(model_name, rt, is_intraday_only)
+    model_name = resolve_forecast_model(
+        model_name,
+        rt,
+        is_intraday_only,
+        adjusted,
+    )
     location_type = rt.location_type
 
     if location_type == models.LocationType.NATION:

--- a/src/quartz_api/internal/service/v1/test_router.py
+++ b/src/quartz_api/internal/service/v1/test_router.py
@@ -2201,3 +2201,34 @@ async def test_last_updated_rejects_unknown_model(client: AsyncClient) -> None:
         f"/v1/GB/solar/regions/{region_id}/forecast/last-updated?model=not_a_model",
     )
     assert resp.status_code == 400
+
+
+_NL_NATIONAL_RT = COUNTRIES["NL"].get_region_type("national")
+
+
+def test_nl_advertises_the_renamed_uncurtailed_slug() -> None:
+    """The PV-inclusive name is the advertised one; the old name is not."""
+    assert _NL_NATIONAL_RT is not None
+    advertised = {m.api_name for m in _NL_NATIONAL_RT.forecast_models}
+    assert advertised == {"blend", "ecmwf_mo_pv_sat_uncurtailed"}
+
+
+@pytest.mark.parametrize(
+    ("legacy_name", "expected_internal"),
+    [
+        # The old name pins the adjuster off, so it returns what it did before the
+        # rename rather than picking up the new adjusted-by-default.
+        ("ecmwf_mo_sat_uncurtailed", "nl_regional_pv_ecmwf_mo_sat_uncurtailed"),
+        (
+            "ecmwf_mo_sat_uncurtailed_adjust",
+            "nl_regional_pv_ecmwf_mo_sat_uncurtailed_adjust",
+        ),
+        ("blend_adjust", "nl_blend_adjust"),
+    ],
+)
+def test_retired_nl_names_still_resolve(
+    legacy_name: str,
+    expected_internal: str,
+) -> None:
+    """Every pre-rename NL name keeps resolving to the same DP forecaster."""
+    assert resolve_forecast_model(legacy_name, _NL_NATIONAL_RT, False) == expected_internal

--- a/src/quartz_api/internal/service/v1/test_router.py
+++ b/src/quartz_api/internal/service/v1/test_router.py
@@ -19,7 +19,8 @@ from quartz_api.internal import eclipse, models
 from quartz_api.internal.backends.dummydb.client import StorageClient
 from quartz_api.internal.middleware.auth import AuthDependency
 
-from .country_config import COUNTRIES
+from .country_config import COUNTRIES, FM, RegionTypeConfig
+from .helpers import resolve_forecast_model
 from .router import router
 
 _auth_dep = typing.get_args(AuthDependency)[1].dependency
@@ -473,7 +474,8 @@ async def test_get_region_types_has_default_model(client: AsyncClient) -> None:
     for rt in resp.json():
         assert "default_model" in rt
     national = next(rt for rt in resp.json() if rt["type"] == "national")
-    assert national["default_model"] == "blend_adjust"
+    # The adjusted variant is reached via ?adjusted, not via the model name.
+    assert national["default_model"] == "blend"
 
 
 @pytest.mark.anyio
@@ -1648,10 +1650,10 @@ async def test_nl_regions_invalid_type_gsp_400(nl_client: AsyncClient) -> None:
 
 @pytest.mark.anyio
 async def test_nl_forecast_default_model(nl_client: AsyncClient) -> None:
-    """NL national forecast returns blend_adjust as the default model."""
+    """NL national forecast returns blend as the default model."""
     resp = await nl_client.get("/v1/NL/solar/regions/national/forecast")
     assert resp.status_code == 200
-    assert resp.json()["model_name"] == "blend_adjust"
+    assert resp.json()["model_name"] == "blend"
 
 
 @pytest.mark.anyio
@@ -1719,11 +1721,15 @@ def test_country_config_intraday_models_subset_of_forecast_models() -> None:
 
 
 def test_country_config_intraday_default_in_intraday_models() -> None:
-    """intraday_default_model must be listed in intraday_models when both are set."""
+    """A region type restricting intraday users must name a default they can have."""
     for country_code, cfg in COUNTRIES.items():
         for rt in cfg.region_types:
-            if rt.intraday_default_model is None or not rt.intraday_models:
+            if not rt.intraday_models:
                 continue
+            assert rt.intraday_default_model is not None, (
+                f"{country_code}/{rt.type}: intraday_models is set but "
+                f"intraday_default_model is not"
+            )
             assert rt.intraday_default_model in rt.intraday_models, (
                 f"{country_code}/{rt.type}: intraday_default_model "
                 f"'{rt.intraday_default_model.api_name}' is not in intraday_models"
@@ -1990,3 +1996,175 @@ async def test_national_snapshot_is_eclipse_adjusted(
     assert values
     for value in values:
         assert value["power_kW"] == pytest.approx(_ECLIPSE_POWER_KW * _ECLIPSE_FACTOR_GB)
+
+
+# ---------------------------------------------------------------------------
+# GB model naming — new slugs, retired aliases, and the trend adjuster boolean
+# ---------------------------------------------------------------------------
+
+_GB_NATIONAL_RT = COUNTRIES["GB"].get_region_type("national")
+_GB_GSP_RT = COUNTRIES["GB"].get_region_type("gsp")
+
+
+@pytest.mark.parametrize(
+    ("api_name", "internal_name"),
+    [
+        ("blend", "blend"),
+        ("ecmwf_mo", "pvnet_day_ahead"),
+        ("ecmwf_mo_sat_8h", "pvnet_v2"),
+        ("ecmwf", "pvnet_ecmwf"),
+        ("sat_8h", "pvnet_sat_only"),
+        ("mo", "pvnet_ukv_only"),
+    ],
+)
+def test_gb_model_slugs_map_to_dp_names(api_name: str, internal_name: str) -> None:
+    """Each new GB slug resolves to the expected internal DP forecaster name."""
+    assert _GB_NATIONAL_RT is not None
+    fm = _GB_NATIONAL_RT.get_model_by_api_name(api_name)
+    assert fm is not None, f"'{api_name}' is not a known GB national model"
+    assert fm.name == internal_name
+    assert fm.adjust_name == f"{internal_name}_adjust"
+
+
+def test_gb_national_advertises_only_the_six_new_names() -> None:
+    """Retired aliases resolve but must not appear in the advertised model list."""
+    assert _GB_NATIONAL_RT is not None
+    assert {m.api_name for m in _GB_NATIONAL_RT.forecast_models} == {
+        "blend",
+        "ecmwf_mo",
+        "ecmwf_mo_sat_8h",
+        "ecmwf",
+        "sat_8h",
+        "mo",
+    }
+
+
+@pytest.mark.parametrize(
+    ("legacy_name", "expected_internal"),
+    [
+        # Unadjusted legacy names pin the adjuster off, adjusted ones pin it on,
+        # so a client on an old name keeps the exact forecast it had before.
+        ("blend_adjust", "blend_adjust"),
+        ("pvnet_intraday", "pvnet_v2"),
+        ("pvnet_intraday_adjust", "pvnet_v2_adjust"),
+        ("pvnet_day_ahead", "pvnet_day_ahead"),
+        ("pvnet_day_ahead_adjust", "pvnet_day_ahead_adjust"),
+        ("pvnet_ecmwf", "pvnet_ecmwf"),
+        ("pvnet_ecmwf_adjust", "pvnet_ecmwf_adjust"),
+        ("pvnet_sat", "pvnet_sat_only"),
+        ("pvnet_sat_adjust", "pvnet_sat_only_adjust"),
+        ("pvnet_ukv", "pvnet_ukv_only"),
+        ("pvnet_ukv_adjust", "pvnet_ukv_only_adjust"),
+    ],
+)
+def test_retired_gb_names_still_resolve(
+    legacy_name: str,
+    expected_internal: str,
+) -> None:
+    """Every pre-rename GB model name keeps resolving to the same DP forecaster."""
+    resolved = resolve_forecast_model(legacy_name, _GB_NATIONAL_RT, False)
+    assert resolved == expected_internal
+
+
+@pytest.mark.parametrize(
+    ("adjusted", "expected"),
+    [(True, "pvnet_v2_adjust"), (False, "pvnet_v2")],
+)
+def test_adjusted_selects_variant(
+    adjusted: bool,
+    expected: str,
+) -> None:
+    """`adjusted` selects between a model's plain and adjusted DP forecasters."""
+    resolved = resolve_forecast_model(
+        "ecmwf_mo_sat_8h",
+        _GB_NATIONAL_RT,
+        False,
+        adjusted,
+    )
+    assert resolved == expected
+
+
+def test_adjusted_defaults_on() -> None:
+    """Omitting the model and the boolean gives the adjusted default forecaster."""
+    assert resolve_forecast_model(None, _GB_NATIONAL_RT, False) == "blend_adjust"
+
+
+def test_adjusted_is_noop_for_gsp() -> None:
+    """GSP has no adjusted DP variants, so the boolean must not alter the name."""
+    assert _GB_GSP_RT is not None
+    assert not _GB_GSP_RT.supports_adjusted
+    for flag in (True, False):
+        assert resolve_forecast_model("blend", _GB_GSP_RT, False, flag) == "blend"
+        assert resolve_forecast_model(None, _GB_GSP_RT, False, flag) == "blend"
+
+
+def test_cache_warms_the_adjusted_default() -> None:
+    """The pre-warmed period cache must use the adjusted default where one exists."""
+    assert _GB_NATIONAL_RT is not None and _GB_GSP_RT is not None
+    assert _GB_NATIONAL_RT.default_forecaster_name() == "blend_adjust"
+    assert _GB_GSP_RT.default_forecaster_name() == "blend"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("model", ["ecmwf_mo_sat_8h", "mo", "pvnet_intraday"])
+async def test_national_forecast_accepts_new_and_legacy_names(
+    nation_response_client: AsyncClient,
+    model: str,
+) -> None:
+    """New slugs and retired aliases are both accepted on the forecast route."""
+    region_id = str(uuid4())
+    resp = await nation_response_client.get(
+        f"/v1/GB/solar/regions/{region_id}/forecast?model={model}",
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_national_forecast_rejects_unknown_model(
+    nation_response_client: AsyncClient,
+) -> None:
+    """A name that is neither a current slug nor an alias is still a 400."""
+    region_id = str(uuid4())
+    resp = await nation_response_client.get(
+        f"/v1/GB/solar/regions/{region_id}/forecast?model=not_a_model",
+    )
+    assert resp.status_code == 400
+    # Only the current names are advertised back to the caller.
+    assert "pvnet" not in resp.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_region_types_expose_supports_adjusted(client: AsyncClient) -> None:
+    """Clients can discover where the `adjusted` param applies without reading docs."""
+    resp = await client.get("/v1/GB/solar/region-types")
+    assert resp.status_code == 200
+    by_type = {rt["type"]: rt for rt in resp.json()}
+    assert by_type["national"]["supports_adjusted"] is True
+    assert by_type["gsp"]["supports_adjusted"] is False
+
+
+def test_intraday_default_never_falls_back_to_unrestricted_model() -> None:
+    """A missing intraday_default_model must not leak the unrestricted default."""
+    rt = RegionTypeConfig(
+        type="gsp",
+        label="Grid Supply Point",
+        level=10,
+        location_type=models.LocationType.GSP,
+        forecast_models=(FM.BLEND, FM.ECMWF_MO_SAT_8H),
+        default_model="blend",
+        intraday_models=(FM.ECMWF_MO_SAT_8H,),
+        intraday_default_model=None,
+    )
+    resolved = resolve_forecast_model(None, rt, is_intraday_only=True)
+    assert resolved == "pvnet_v2", "intraday-only caller received the unrestricted default"
+
+
+def test_no_configured_default_sends_no_forecaster_filter() -> None:
+    """A region type with no default_model resolves to None, letting the DP choose."""
+    rt = RegionTypeConfig(
+        type="dno",
+        label="DNO",
+        level=5,
+        location_type=models.LocationType.DNO,
+    )
+    assert resolve_forecast_model(None, rt, is_intraday_only=False) is None

--- a/src/quartz_api/internal/service/v1/test_router.py
+++ b/src/quartz_api/internal/service/v1/test_router.py
@@ -2168,3 +2168,36 @@ def test_no_configured_default_sends_no_forecaster_filter() -> None:
         location_type=models.LocationType.DNO,
     )
     assert resolve_forecast_model(None, rt, is_intraday_only=False) is None
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("model", ["blend_adjust", "pvnet_intraday_adjust"])
+async def test_gsp_rejects_adjust_aliases(client: AsyncClient, model: str) -> None:
+    """GSP has no adjusted variants, so an `_adjust` name is a 400, not silent fallback."""
+    region_id = str(uuid4())
+    resp = await client.get(
+        f"/v1/GB/solar/regions/{region_id}/forecast?model={model}",
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_national_still_accepts_adjust_aliases(
+    nation_response_client: AsyncClient,
+) -> None:
+    """National does have adjusted variants, so the same names keep working there."""
+    region_id = str(uuid4())
+    resp = await nation_response_client.get(
+        f"/v1/GB/solar/regions/{region_id}/forecast?model=blend_adjust",
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_last_updated_rejects_unknown_model(client: AsyncClient) -> None:
+    """last-updated validates the model rather than passing it to the backend."""
+    region_id = str(uuid4())
+    resp = await client.get(
+        f"/v1/GB/solar/regions/{region_id}/forecast/last-updated?model=not_a_model",
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
# Pull Request

## Description

Rename the user-facing GB forecast models to describe their **input sets** rather than internal model names, so they line up across products, and move the trend adjuster out of the model name into an `adjusted` boolean. Internal DP forecaster names are unchanged — this is a naming and parameter change only.

| `model` | Inputs | Internal DP forecaster | Retired names still accepted |
|---|---|---|---|
| `blend` | blend of all models | `blend` | `blend_adjust` |
| `ecmwf_mo` | ECMWF + Met Office (day-ahead: NWPs only) | `pvnet_day_ahead` | `pvnet_day_ahead`, `pvnet_day_ahead_adjust` |
| `ecmwf_mo_sat_8h` | ECMWF + Met Office + satellite (~8h) | `pvnet_v2` | `pvnet_intraday`, `pvnet_intraday_adjust` |
| `ecmwf` | ECMWF only | `pvnet_ecmwf` | `pvnet_ecmwf`, `pvnet_ecmwf_adjust` |
| `sat_8h` | satellite only (~8h) | `pvnet_sat_only` | `pvnet_sat`, `pvnet_sat_adjust` |
| `mo` | Met Office only | `pvnet_ukv_only` | `pvnet_ukv`, `pvnet_ukv_adjust` |

National exposes all six; GSP exposes `blend`, `ecmwf_mo_sat_8h` and `ecmwf_mo`.

**`adjusted` boolean, defaulting to on** — `?adjusted=true|false` on `/regions/{id}/forecast`, `/forecast/last-updated` and `/forecasts/snapshot`. It is orthogonal to model choice and every adjustable model has an adjusted variant, so defaulting it on means callers get the best available forecast without knowing to ask. Leaves room to become a select later, or to disappear if the adjustment moves into the model pipeline.

Not every region type has adjusted variants — GB `gsp` and NL `province` have none. There the param is ignored rather than rejected: a 400 would force a caller sweeping several region types to special-case GSP. `GET /region-types` now returns `supports_adjusted` per type so that stays discoverable instead of silent.

`model_name` in responses no longer carries an `_adjust` suffix, matching v0, which stripped it before returning it too.

**Scope**
- GB naming only. NL slugs are unchanged; NL picks up the `adjusted` param and the alias mechanism for free.
- Not on `/forecasts/period` or `/generation/period` — those are cache-only and serve the pre-warmed default (adjusted); adding the param would mean warming two variants per region. 

## Backwards compatibility

The retired names in the table above are carried on `ForecastModel.aliases` / `adjust_aliases` and stay out of `/region-types`, the OpenAPI enum and 400 messages, so existing integrations keep working while new ones only ever see the current names. An alias pins its own adjuster state — the `_adjust` ones pin it on, the rest pin it off — so an old name returns byte-for-byte what it did before.

**⚠️ One behaviour change.** `blend` is both a current name and a pre-rename name, so it cannot carry an alias override: it takes the new `adjusted=true` default and now returns the adjusted blend where it previously returned the plain one. `?adjusted=false` restores the old result. Our one external tester is on `blend`, so this wants a heads-up before it ships.

## Also included

If a region type restricted intraday users but named no `intraday_default_model`, an intraday-only caller who omitted `model` got no forecaster filter at all — we sent nothing and let the data platform choose(?) or perhaps reject the request. The fallback now stays inside the intraday set, and the config invariant test requires an intraday default whenever `intraday_models` is set.

Both GB region types name one atm, so not a "now" problem but good to tighten up now rather than spotting later and having to hotfix.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
