### PR TITLE
fix: enhance missing timestamp detection to include a 30-minute buffe…

### DIFF
--- a/src/quartz_api/internal/service/satellite/_ingest.py
+++ b/src/quartz_api/internal/service/satellite/_ingest.py
@@ -74,8 +74,10 @@ def _find_missing_timestamps(
         return []
 
     expected = min(existing_timestamps)
+    #this end helps checking for stale data, with 30min buffer
+    end = max(max(existing_timestamps), dt.datetime.now(dt.UTC) - dt.timedelta(minutes=30))
     missing = []
-    while expected <= max(existing_timestamps):
+    while expected <= end:
         if expected not in existing_timestamps:
             missing.append(expected)
         expected += interval


### PR DESCRIPTION
# Pull Request

## Description

Continuation of https://github.com/openclimatefix/quartz-api/pull/382

enhance missing timestamp detection to include a 30-minute buffer for stale data

## How Has This Been Tested?

- [x] Locally

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
