### PR TITLE
fix: always return UTC timestamps from /sites/{uuid}/forecast

### DIFF
--- a/src/quartz_api/internal/service/sites/router.py
+++ b/src/quartz_api/internal/service/sites/router.py
@@ -173,7 +173,6 @@ async def get_forecast(
     site_uuid: UUID,
     db: models.StorageClientDependency,
     auth: AuthDependency,
-    tz: models.TZDependency,
 ) -> list[PredictedPower]:
     """Get forecast of a site (Solar or Wind, auto-detected)."""
     site = await _get_site_with_energy_type(db, site_uuid, auth)
@@ -201,11 +200,13 @@ async def get_forecast(
         authdata=auth,
         forecaster_name=forecaster_name,
     )
+    # Time is always returned in UTC, matching the legacy (v0.2.4) India API this
+    # replaces, rather than converted to the deployment's configured tz.
     out: list[PredictedPower] = [
         PredictedPower(
             PowerKW=v.power_kilowatts,
-            Time=v.valid_timestamp.astimezone(tz=tz),
-            created_time=v.created_timestamp.astimezone(tz=tz),
+            Time=v.valid_timestamp.astimezone(tz=dt.UTC),
+            created_time=v.created_timestamp.astimezone(tz=dt.UTC),
             forecaster_name=v.forecaster_name,
             forecaster_version=v.forecaster_version,
         )


### PR DESCRIPTION
## Description

The `/sites/{uuid}/forecast` endpoint converted `Time` and `created_time` to the deployment's configured timezone (`Asia/Kolkata` for the India deployment, producing `+05:30` offsets), while the legacy India API this replaces always returns UTC (`Z` suffix). This forces both fields to UTC on the new endpoint too, matching old exactly, and drops the now-unused `tz` dependency parameter (it wasn't a client-facing query param, so this doesn't change the public API surface).

## How Has This Been Tested?

Ran the patched endpoint locally (`uvicorn` on `:8123`, `SOURCE=dataplatform`) and compared its live HTTP responses against the deployed old (elasticbeanstalk) API for the same site/window, using the same bearer token for both. Confirmed across all 8 Adani sites.

**Deployed new API (before fix) — `+05:30` offset:**
```json
[
  {"PowerKW": 0.0, "Time": "2026-09-07T05:30:00+05:30"},
  {"PowerKW": 0.0, "Time": "2026-09-07T05:45:00+05:30"},
  {"PowerKW": 0.0, "Time": "2026-09-07T06:00:00+05:30"},
  {"PowerKW": 21491.0, "Time": "2026-09-07T06:15:00+05:30"},
  {"PowerKW": 29175.0, "Time": "2026-09-07T06:30:00+05:30"}
]
```

**Old API (reference) — UTC:**
```json
[
  {"PowerKW": 0.0, "Time": "2026-09-07T00:00:00Z"},
  {"PowerKW": 0.0, "Time": "2026-09-07T00:15:00Z"},
  {"PowerKW": 0.0, "Time": "2026-09-07T00:30:00Z"},
  {"PowerKW": 21498.0, "Time": "2026-09-07T00:45:00Z"},
  {"PowerKW": 29177.0, "Time": "2026-09-07T01:00:00Z"}
]
```

**Local patched new API (after fix) — UTC, matches old:**
```json
[
  {"PowerKW": 0.0, "Time": "2026-09-07T00:00:00Z"},
  {"PowerKW": 0.0, "Time": "2026-09-07T00:15:00Z"},
  {"PowerKW": 0.0, "Time": "2026-09-07T00:30:00Z"},
  {"PowerKW": 21491.0, "Time": "2026-09-07T00:45:00Z"},
  {"PowerKW": 29175.0, "Time": "2026-09-07T01:00:00Z"}
]
```

Timestamps now match exactly (same format, same starting instant). 


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
